### PR TITLE
ATA + SCSI FARM Log Parsing

### DIFF
--- a/smartmontools/atacmds.h
+++ b/smartmontools/atacmds.h
@@ -605,62 +605,64 @@ STATIC_ASSERT(sizeof(ata_sct_temperature_history_table) == 512);
 // Log Header
 #pragma pack(1)
 struct ataFarmHeader {
-	uint64_t        signature;        // Log signature = 0x00004641524D4552
-	uint64_t        majorRev;         // Log major revision
-	uint64_t        minorRev;         // Log minor revision
-	uint64_t        pagesSupported;   // Number of pages supported
-	uint64_t        logSize;          // Log size in bytes
-	uint64_t        pageSize;         // Page size in bytes
-	uint64_t        headsSupported;   // Maximum drive heads supported
-	uint64_t        copies;           // Number of historical copies
+	uint64_t        signature;        // Log Signature = 0x00004641524D4552
+	uint64_t        majorRev;         // Log Major Revision
+	uint64_t        minorRev;         // Log Rinor Revision
+	uint64_t        pagesSupported;   // Number of Pages Supported
+	uint64_t        logSize;          // Log Size in Bytes
+	uint64_t        pageSize;         // Page Size in Bytes
+	uint64_t        headsSupported;   // Maximum Drive Heads Supported
+	uint64_t        copies;           // Number of Historical Copies
+  uint64_t        frameCapture;     // Reason for Frame Capture
 } ATTR_PACKED;
 #pragma pack()
-STATIC_ASSERT(sizeof(ataFarmHeader) == 64);
+STATIC_ASSERT(sizeof(ataFarmHeader) == 72);
 
 // Seagate Field Access Reliability Metrics log (FARM) page 1 (read with ATA_READ_LOG_EXT address 0xa6, page 1)
 // Drive Information
 #pragma pack(1)
 struct ataFarmDriveInformation {
-	uint64_t        pageNumber;           // Page Number = 1
-	uint64_t        copyNumber;           // Copy Number
-	uint64_t        serialNumber;         // Serial Number
-	uint64_t        serialNumber2;        // Serial Number 2
-	uint64_t        worldWideName;        // World Wide Name 
-	uint64_t        worldWideName2;       // World Wide Name 2
-	uint64_t        deviceInterface;      // Device Interface
-	uint64_t        deviceCapacity;       // 48-bit Device Capacity
-	uint64_t        psecSize;             // Physical Sector Size in Bytes
-	uint64_t        lsecSize;             // Logical Sector Size in Bytes
-	uint64_t        deviceBufferSize;     // Device Buffer Size in Bytes
-	uint64_t        heads;                // Number of Heads
-	uint64_t        factor;               // Device Form Factor (ID Word 168)
-	uint64_t        rotationRate;         // Rotational Rate of Device (ID Word 217)
-	uint64_t        firmware;             // Firmware 
-	uint64_t        firmwareRev;          // Firmware Revision
-	uint64_t        security;             // ATA Security State (ID Word 128)
-	uint64_t        featuresSupported;    // ATA Features Supported (ID Word 78)
-	uint64_t        featuresEnabled;      // ATA Features Enabled (ID Word 79)
-	uint64_t        poh;                  // Power-On Hours
-	uint64_t        spoh;                 // Spindle Power-On Hours
-	uint64_t        headFlightHours;      // Head Flight Hours
-	uint64_t        headLoadEvents;       // Head Load Events
-	uint64_t        powerCycleCount;      // Power Cycle Count
-	uint64_t        resetCount;           // Hardware Reset Count
-	uint64_t        spinUpTime;           // SMART Spin-Up Time in milliseconds
-	uint64_t        NVC_StatusATPowerOn;  // NVC Status on Power-On
-	uint64_t        timeAvailable;        // Time Available to Save User Data to Media Over Last Power Cycle (in 100us)
-	uint64_t        timeStamp1;           // Timestamp of latest SMART Summary Frame in Power-On Hours Milliseconds
-	uint64_t        timeStamp2;           // Timestamp of latest SMART Summary Frame in Power-On Hours Milliseconds
-	uint64_t        timeToReady;					// Time to ready of the last power cycle
-	uint64_t        timeHeld;							// Time drive is held in staggered spin during the last power on sequence
-  uint64_t        modelNumber[10];      // Lower 32 Model Number (added 2.14)
-  uint64_t        driveRecordingType;   // 0 for SMR and 1 for CMR (added 2.15)
-  uint64_t        depopped;             // Has the drive been depopped  1 = depopped and 0 = not depopped (added 2.15)
-  uint64_t        maxNumberForReasign;  // Max Number of Available Sectors for Reassignment – Value in disc sectors (added 3.3)
-  uint64_t        dateOfAssembly;       // Date of assembly in ASCII “YYWW” where YY is the year and WW is the calendar week (added 4.2)
+	uint64_t        pageNumber;             // Page Number = 1
+	uint64_t        copyNumber;             // Copy Number
+	uint64_t        serialNumber;           // Serial Number [0:3]
+	uint64_t        serialNumber2;          // Serial Number [4:7]
+	uint64_t        worldWideName;          // World Wide Name [0:3]
+	uint64_t        worldWideName2;         // World Wide Name [4:7]
+	uint64_t        deviceInterface;        // Device Interface
+	uint64_t        deviceCapacity;         // 48-bit Device Capacity
+	uint64_t        psecSize;               // Physical Sector Size in Bytes
+	uint64_t        lsecSize;               // Logical Sector Size in Bytes
+	uint64_t        deviceBufferSize;       // Device Buffer Size in Bytes
+	uint64_t        heads;                  // Number of Heads
+	uint64_t        factor;                 // Device Form Factor (ID Word 168)
+	uint64_t        rotationRate;           // Rotational Rate of Device (ID Word 217)
+	uint64_t        firmwareRev;            // Firmware Revision [0:3]
+	uint64_t        firmwareRev2;           // Firmware Revision [4:7]
+	uint64_t        security;               // ATA Security State (ID Word 128)
+	uint64_t        featuresSupported;      // ATA Features Supported (ID Word 78)
+	uint64_t        featuresEnabled;        // ATA Features Enabled (ID Word 79)
+	uint64_t        poh;                    // Power-On Hours
+	uint64_t        spoh;                   // Spindle Power-On Hours
+	uint64_t        headFlightHours;        // Head Flight Hours
+	uint64_t        headLoadEvents;         // Head Load Events
+	uint64_t        powerCycleCount;        // Power Cycle Count
+	uint64_t        resetCount;             // Hardware Reset Count
+	uint64_t        spinUpTime;             // SMART Spin-Up Time in milliseconds
+	uint64_t        reserved;               // Reserved
+	uint64_t        reserved;               // Reserved
+	uint64_t        reserved;               // Reserved
+	uint64_t        reserved;               // Reserved
+	uint64_t        timeToReady;			      // Time to ready of the last power cycle
+	uint64_t        timeHeld;					      // Time drive is held in staggered spin during the last power on sequence
+  uint64_t        modelNumber[10];        // Lower 32 Model Number (added 2.14)
+  uint64_t        driveRecordingType;     // 0 for SMR and 1 for CMR (added 2.15)
+  uint64_t        depopped;               // Has the drive been depopped  1 = depopped and 0 = not depopped (added 2.15)
+  uint64_t        maxNumberForReasign;    // Max Number of Available Sectors for Reassignment – Value in disc sectors (added 3.3)
+  uint64_t        dateOfAssembly;         // Date of assembly in ASCII “YYWW” where YY is the year and WW is the calendar week (added 4.2)
+  uint64_t        depopulationHeadMask;   // Depopulation Head Mask
 } ATTR_PACKED;
 #pragma pack()
-STATIC_ASSERT(sizeof(ataFarmDriveInformation) == 368);
+STATIC_ASSERT(sizeof(ataFarmDriveInformation) == 376);
 
 // Seagate Field Access Reliability Metrics log (FARM) page 2 (read with ATA_READ_LOG_EXT address 0xa6, page 2)
 // Workload Statistics
@@ -668,7 +670,7 @@ STATIC_ASSERT(sizeof(ataFarmDriveInformation) == 368);
 struct ataFarmWorkloadStatistics {
 	uint64_t        pageNumber;               // Page Number = 2
 	uint64_t        copyNumber;               // Copy Number
-	uint64_t        workloadPercentage;       // Rated Workload Percentage
+	uint64_t        reserved;                 // Reserved
 	uint64_t        totalReadCommands;        // Total Number of Read Commands
 	uint64_t        totalWriteCommands;       // Total Number of Write Commands
 	uint64_t        totalRandomReads;         // Total Number of Random Read Commands
@@ -678,7 +680,7 @@ struct ataFarmWorkloadStatistics {
 	uint64_t        logicalSecRead;           // Logical Sectors Read
   uint64_t        dither;                   // Number of dither events during current power cycle (added 3.4)
   uint64_t        ditherRandom;             // Number of times dither was held off during random workloads during current power cycle (added 3.4)
-  uint64_t        ditherSequential;         // Number of times dither was held off during sequential workloads during current power cycle (added 3.4) 
+  uint64_t        ditherSequential;         // Number of times dither was held off during sequential workloads during current power cycle (added 3.4)
   uint64_t        readCommandsByRadius1;    // Number of Read Commands from 0-3.125% of LBA space for last 3 SMART Summary Frames (added 4.4)
   uint64_t        readCommandsByRadius2;    // Number of Read Commands from 3.125-25% of LBA space for last 3 SMART Summary Frames (added 4.4)
   uint64_t        readCommandsByRadius3;    // Number of Read Commands from 25-75% of LBA space for last 3 SMART Summary Frames (added 4.4)
@@ -695,34 +697,39 @@ STATIC_ASSERT(sizeof(ataFarmWorkloadStatistics) == 168);
 // Error Statistics
 #pragma pack(1)
 struct ataFarmErrorStatistics {
-	uint64_t         pageNumber;                          // Page Number = 3
-	uint64_t         copyNumber;                          // Copy Number
-	uint64_t         totalReadECC;                        // Number of Unrecoverable Read Errors
-	uint64_t         totalWriteECC;                       // Number of Unrecoverable Write Errors
-	uint64_t         totalReallocations;                  // Number of Re-allocated Sectors
-	uint64_t         totalReadRecoveryAttepts;            // Number of Read Recovery Attempts
-	uint64_t         totalMechanicalFails;                // Number of Mechanical Start Failures
-	uint64_t         totalReallocatedCanidates;           // Number of Re-allocated Candidate Sectors
-	uint64_t         totalASREvents;                      // Number of ASR Events
-	uint64_t         totalCRCErrors;                      // Number of Interface CRC Errors
-	uint64_t         attrSpinRetryCount;                  // Spin Retry Count 
-	uint64_t         normalSpinRetryCount;                // Spin Retry Count 
-	uint64_t         worstSpinRretryCount;                // Spin Retry Count 
-	uint64_t         attrIOEDCErrors;                     // Number of IOEDC Errors 
-	uint64_t         attrCTOCount;                        // CTO Count Total 
-	uint64_t         overfiveSecCTO;                      // CTO Count Over 5s 
-	uint64_t         oversevenSecCTO;                     // CTO Count Over 7.5s 
-	uint64_t         totalFlashLED;                       // Total Flash LED (Assert) Events
-	uint64_t         indexFlashLED;                       // Index of the last Flash LED of the array
-	uint64_t         uncorrectables;                      // Uncorrectable errors (SMART Attribute 187 Raw)
-  uint64_t         smartTrip;                           // FRU code if SMART trip from most recent SMART Frame (SAS Only) 
-	uint64_t         flashLEDArray[8];                    // Info on the last 8 Flash LED (assert) events wrapping array (added 2.7)
-  uint64_t         readWriteRetry[8];                   // Info on the last 8 read/write retry events (added 2.7)
-  uint64_t         superParityOnTheFlyRecoveryCnt[2];   // Super Parity on the Fly Recovery counters  (added 3.0)
-  uint64_t         reallocatedSectors[15];              // Re-allocated Sectors by cause (added 3.0)
+	uint64_t        pageNumber;                                 // Page Number = 3
+	uint64_t        copyNumber;                                 // Copy Number
+	uint64_t        totalUnrecoverableReadErrors;               // Number of Unrecoverable Read Errors
+	uint64_t        totalUnrecoverableWriteErrors;              // Number of Unrecoverable Write Errors
+	uint64_t        totalReallocations;                         // Number of Re-allocated Sectors
+	uint64_t        totalReadRecoveryAttepts;                   // Number of Read Recovery Attempts
+	uint64_t        totalMechanicalStartRetries;                // Number of Mechanical Start Retries
+	uint64_t        totalReallocationCanidates;                 // Number of Re-allocation Candidate Sectors
+	uint64_t        totalASREvents;                             // Number of ASR Events
+	uint64_t        totalCRCErrors;                             // Number of Interface CRC Errors
+	uint64_t        attrSpinRetryCount;                         // Spin Retry Count (Most recent value from array at byte 401 of attribute sector)
+	uint64_t        normalSpinRetryCount;                       // Spin Retry Count (SMART Attribute 10 Normalized)
+	uint64_t        worstSpinRretryCount;                       // Spin Retry Count (SMART Attribute 10 Worst Ever)
+	uint64_t        attrIOEDCErrors;                            // Number of IOEDC Errors (SMART Attribute 184 Raw)
+	uint64_t        attrCTOCount;                               // CTO Count Total (SMART Attribute 188 Raw[0..1])
+	uint64_t        overfiveSecCTO;                             // CTO Count Over 5s (SMART Attribute 188 Raw[2..3])
+	uint64_t        oversevenSecCTO;                            // CTO Count Over 7.5s (SMART Attribute 188 Raw[4..5])
+	uint64_t        totalFlashLED;                              // Total Flash LED (Assert) Events
+	uint64_t        indexFlashLED;                              // Index of last entry in Flash LED Info array below, in case the array wraps
+	uint64_t        uncorrectables;                             // Uncorrectable errors (SMART Attribute 187 Raw)
+  uint64_t        reserved;                                   // Reserved
+  uint64_t        flashLEDArray[8];                           // Info on the last 8 Flash LED (assert) events wrapping array (added 2.7)
+  uint64_t        reserved[8];                                // Reserved
+  uint64_t        reserved[2];                                // Reserved
+  uint64_t        reserved[15];                               // Reserved
+  uint64_t        universalTimestampFlashLED[8];              // Universal Timestamp (us) of last 8 Flash LED (assert) Events, wrapping array
+  uint64_t        powerCycleFlashLED[8];                      // Power Cycle of the last 8 Flash LED (assert) Events, wrapping array
+  uint64_t        cumulativeUnrecoverableReadERC;             // Cumulative Lifetime Unrecoverable Read errors due to Error Recovery Control (e.g. ERC timeout)
+  uint64_t        cumulativeUnrecoverableReadRepeating[24];   // Cumulative Lifetime Unrecoverable Read Repeating by head
+  uint64_t        cumulativeUnrecoverableReadUnique[24];      // Cumulative Lifetime Unrecoverable Read Unique by head
 } ATTR_PACKED;
 #pragma pack()
-STATIC_ASSERT(sizeof(ataFarmErrorStatistics) == 432);
+STATIC_ASSERT(sizeof(ataFarmErrorStatistics) == 952);
 
 // Seagate Field Access Reliability Metrics log (FARM) page 4 (read with ATA_READ_LOG_EXT address 0xa6, page 4)
 // Environment Statistics
@@ -732,28 +739,28 @@ struct ataFarmEnvironmentStatistics {
 	uint64_t         copyNumber;          // Copy Number
 	uint64_t         curentTemp;          // Current Temperature in Celsius
 	uint64_t         highestTemp;         // Highest Temperature in Celsius
-	uint64_t         lowestTemp;          // Lowest Temperature
-	uint64_t         averageTemp;         // Average Short-Term Temperature
-	uint64_t         averageLongTemp;     // Average Long-Term Temperature
-	uint64_t         highestShortTemp;    // Highest Average Short-Term Temperature
-	uint64_t         lowestShortTemp;     // Lowest Average Short-Term Temperature
-	uint64_t         highestLongTemp;     // Highest Average Long-Term Temperature
-	uint64_t         lowestLongTemp;      // Lowest Average Long-Term Temperature
-	uint64_t         overTempTime;        // Time In Over Temperature
-	uint64_t         underTempTime;       // Time In Under Temperature
-	uint64_t         maxTemp;             // Specified Max Operating Temperature
-	uint64_t         minTemp;             // Specified Min Operating Temperature
-	uint64_t         shockEvents;         // Over-Limit Shock Events Count
-	uint64_t         hfWriteCounts;       // High Fly Write Count 
+	uint64_t         lowestTemp;          // Lowest Temperature in Celsius
+	uint64_t         averageTemp;         // Average Short-Term Temperature in Celsius
+	uint64_t         averageLongTemp;     // Average Long-Term Temperature in Celsius
+	uint64_t         highestShortTemp;    // Highest Average Short-Term Temperature in Celsius
+	uint64_t         lowestShortTemp;     // Lowest Average Short-Term Temperature in Celsius
+	uint64_t         highestLongTemp;     // Highest Average Long-Term Temperature in Celsius
+	uint64_t         lowestLongTemp;      // Lowest Average Long-Term Temperature in Celsius
+	uint64_t         overTempTime;        // Time In Over Temperature in Minutes
+	uint64_t         underTempTime;       // Time In Under Temperature in Minutes
+	uint64_t         maxTemp;             // Specified Max Operating Temperature in Celsius
+	uint64_t         minTemp;             // Specified Min Operating Temperature in Celsius
+	uint64_t         reserved;            // Reserved
+	uint64_t         reserved;            // Reserved
 	uint64_t         humidity;            // Current Relative Humidity (in units of 0.1%)
-	uint64_t         humidityRatio;       // Humidity Mixed Ratio multiplied by 8 (divide by 8 to get actual value)
+	uint64_t         reserved;            // Reserved
 	uint64_t         currentMotorPower;   // Current Motor Power, value from most recent SMART Summary Frame
   uint64_t         current12v;          // Current 12V input (added 3.7)
-  uint64_t         min12v;              // Minimum 12V input from last 3 SMART Summary Frames (added 3.7)
-  uint64_t         max12v;              // Maximum 12V input from last 3 SMART Summary Frames (added 3.7)
-  uint64_t         current5v;           // Current 5V input (added 3.7)
-  uint64_t         min5v;               // Minimum 5V input from last 3 SMART Summary Frames (added 3.7)
-  uint64_t         max5v;               // Maximum 5V input from last 3 SMART Summary Frames (added 3.7)
+  uint64_t         min12v;              // Minimum 12V input from last 3 SMART Summary Frames in mV (added 3.7)
+  uint64_t         max12v;              // Maximum 12V input from last 3 SMART Summary Frames in mV (added 3.7)
+  uint64_t         current5v;           // Current 5V input in mV (added 3.7)
+  uint64_t         min5v;               // Minimum 5V input from last 3 SMART Summary Frames in mV (added 3.7)
+  uint64_t         max5v;               // Maximum 5V input from last 3 SMART Summary Frames in mV (added 3.7)
   uint64_t         powerAverage12v;     // 12V Power Average (mW) - Average of last 3 SMART Summary Frames (added 4.3)
   uint64_t         powerMin12v;         // 12V Power Min (mW) - Lowest of last 3 SMART Summary Frames (added 4.3)
   uint64_t         powerMax12v;         // 12V Power Max (mW) - Highest of last 3 SMART Summary Frames (added 4.3)
@@ -770,23 +777,23 @@ STATIC_ASSERT(sizeof(ataFarmEnvironmentStatistics) == 256);
 struct ataFarmReliabilityStatistics {
 	int64_t         pageNumber;                         // Page Number = 5
 	int64_t         copyNumber;                         // Copy Number
-	int64_t         lastIDDTest;                        // Timestamp of last IDD test
-	int64_t         cmdLastIDDTest;                     // Sub-command of last IDD test
-  uint64_t        discSlip[24];                       // [24] Disc Slip in micro-inches by Head
-  uint64_t        bitErrorRate[24];                   // [24] Bit Error Rate of Zone 0 by Drive Head
-	int64_t         gListReclamed;                      // Number of G-List Reclamations 
-	int64_t         servoStatus;                        // Servo Status (follows standard DST error code definitions)
-	int64_t         altsBeforeIDD;                      // Number of Alt List Entries Before IDD Scan
-	int64_t         altsAfterIDD;                       // Number of Alt List Entries After IDD Scan
-	int64_t         gListBeforIDD;                      // Number of Resident G-List Entries Before IDD Scan
-	int64_t         gListAfterIDD;                      // Number of Resident G-List Entries After IDD Scan
-	int64_t         scrubsBeforeIDD;                    // Number of Scrub List Entries Before IDD Scan
-	int64_t         scrubsAfterIDD;                     // Number of Scrub List Entries After IDD Scan
-	int64_t         numberDOSScans;                     // Number of DOS Scans Performed
-	int64_t         numberLBACorrect;                   // Number of LBAs Corrected by ISP
-	int64_t         numberValidParitySec;               // Number of Valid Parity Sectors
-	int64_t         dosWriteCount[24];                  // [24] DOS Write Refresh Count
-	int64_t         numberRAWops;                       // Number of RAW Operations
+	uint64_t        reserved;                           // Reserved
+	uint64_t        reserved;                           // Reserved
+  uint64_t        reserved[24];                       // Reserved
+  uint64_t        reserved[24];                       // Reserved
+	uint64_t        reserved;                           // Reserved
+	uint64_t        reserved;                           // Reserved
+	uint64_t        reserved;                           // Reserved
+	uint64_t        reserved;                           // Reserved
+	uint64_t        reserved;                           // Reserved
+	uint64_t        reserved;                           // Reserved
+	uint64_t        reserved;                           // Reserved
+	uint64_t        reserved;                           // Reserved
+	uint64_t        reserved;                           // Reserved
+	uint64_t        reserved;                           // Reserved
+	uint64_t        reserved;                           // Reserved
+	uint64_t        reserved[24];                       // Reserved
+	uint64_t        reserved;                           // Reserved
 	int64_t         DVGASkipWriteDetect[24];            // [24] DVGA Skip Write Detect by Head
 	int64_t         RVGASkipWriteDetect[24];            // [24] RVGA Skip Write Detect by Head
 	int64_t         FVGASkipWriteDetect[24];            // [24] FVGA Skip Write Detect by Head
@@ -798,36 +805,42 @@ struct ataFarmReliabilityStatistics {
 	int64_t         attrSeekErrorRateNormal;            // Seek Error Rate Normalized
 	int64_t         attrSeekErrorRateWorst;             // Seek Error Rate Worst
 	int64_t         attrUnloadEventsRaw;                // High Priority Unload Events 
-	uint64_t        microActuatorLockOut;               // Micro Actuator Lock-out, head mask accumulated over last 3 Summary Frames
-	int64_t         sineACFF[24];                       // [24] ACFF Sine 1X, value from most recent SMART Summary Frame by Head
-	int64_t         cosineACFF[24];                     // [24] ACFF Cosine 1X, value from most recent SMART Summary Frame by Head
-	int64_t         PZTCalibration[24];                 // [24] PZT Calibration, value from most recent SMART Summary Frame by Head
-	int64_t         MRHeadResistance[24];               // [24] MR Head Resistance from most recent SMART Summary Frame by Head
-	int64_t         numberOfTMD[24];                    // [24] Number of TMD over last 3 SMART Summary Frames by Head
-	int64_t         velocityObserver[24];               // [24] Velocity Observer over last 3 SMART Summary Frames by Head
-	int64_t         numberOfVelocityObserver[24];       // [24] Number of Velocity Observer over last 3 SMART Summary Frames by Head
-	int64_t         currentH2SAT[24][3];                // [24][3] Current H2SAT trimmed mean bits in error by Head, by Test Zone 
-	int64_t         currentH2SATIterations[24][3];      // [24][3] Current H2SAT iterations to converge by Head, by Test Zone 
-	int64_t         currentH2SATPercentage[24];         // [24] Current H2SAT percentage of codewords at iteration level by Head, averaged
-	int64_t         currentH2SATAmplitude[24];          // [24] Qword[24] Current H2SAT amplitude by Head, averaged across Test Zones 
-	int64_t         currentH2SATAsymmetry[24];          // [24] Qword[24] Current H2SAT asymmetry by Head, averaged across Test Zones
-	int64_t         flyHeightClearance[24][3];          // [24][3] Applied fly height clearance delta per head in thousandths of one Angstrom
-	int64_t         diskSlipRecalPerformed;             // Number of disc slip recalibrations performed
-	int64_t         gList[24];                          // [24] Number of Resident G-List per Head
-	int64_t         pendingEntries[24];                 // [24] Number of pending Entries per Head
-	int64_t         heliumPresureTrip;                  // Helium Pressure Threshold Tripped ( 1- trip, 0 -no trip)
-	int64_t         oughtDOS[24];                       // [24] DOS Ought to scan count per head
-	int64_t         needDOS[24];                        // [24] DOS needs to scanns count per head
-	int64_t         writeDOSFault[24];                  // [24] DOS  write Fault scans per head
-	int64_t         writePOH[24];                       // [24] Write POS in sec value from most recent SMART Frame by head
-	int64_t         RVAbsoluteMean;                     // RV Absolute Mean, value from the most recent SMART Frame
-	int64_t         maxRVAbsoluteMean;                  // Max RV Absolute Mean, value from the most recent SMART Summary Frame
-	int64_t         idleTime;                           // Idle Time, Value from most recent SMART Summary Frame
-	int64_t         countDOSWrite[24];                  // [24] DOS Write Count Threshold per head
-  int64_t         secondMRHeadResistance[24];         // [24] Second Head, MR Head Resistance from most recent SMART Summary Frame by Head (added 2.11)
+	uint64_t        reserved;                           // Reserved
+	uint64_t        reserved[24];                       // Reserved
+	uint64_t        reserved[24];                       // Reserved
+	uint64_t        reserved[24];                       // Reserved
+	uint64_t        reserved[24];                       // Reserved
+	uint64_t        reserved[24];                       // Reserved
+	uint64_t        reserved[24];                       // Reserved
+	uint64_t        reserved[24];                       // Reserved
+	uint64_t        reserved[24][3];                    // Reserved
+	uint64_t        reserved[24][3];                    // Reserved
+	uint64_t        reserved[24];                       // Reserved
+	uint64_t        reserved[24];                       // Reserved
+	uint64_t        reserved[24];                       // Reserved
+	uint64_t        reserved[24][3];                    // Reserved
+	uint64_t        reserved;                           // Reserved
+	int64_t         reallocatedSectors[24];             // [24] Number of Reallocated Sectors per Head
+	int64_t         reallocationCandidates[24];         // [24] Number of Reallocation Candidate Sectors per Head
+	int64_t         heliumPresureTrip;                  // Helium Pressure Threshold Tripped ( 1 - trip, 0 - no trip)
+  uint64_t        reserved[24];                       // Reserved
+  uint64_t        reserved[24];                       // Reserved
+  uint64_t        reserved[24];                       // Reserved
+	int64_t         writeWorkloadPowerOnTime[24];       // [24] Write Workload Power-on Time in Seconds, value from most recent SMART Summary Frame by Head
+	uint64_t        reserved;                           // Reserved
+	uint64_t        reserved;                           // Reserved
+	uint64_t        reserved;                           // Reserved
+  uint64_t        reserved[24];                       // Reserved
+  int64_t         secondMRHeadResistance[24];         // [24] Second Head, MR Head Resistance from most recent SMART Summary Frame by Head
+  uint64_t        reserved[24];                       // Reserved
+  uint64_t        reserved[24];                       // Reserved
+  uint64_t        reserved[24][3];                    // Reserved
+  uint64_t        reserved[24][3];                    // Reserved
+  uint64_t        reserved[24][3];                    // Reserved
+	int64_t         numberLBACorrectedParitySector;     // Number of LBAs Corrected by Parity Sector
 } ATTR_PACKED;
 #pragma pack()
-STATIC_ASSERT(sizeof(ataFarmReliabilityStatistics) == 6760);
+STATIC_ASSERT(sizeof(ataFarmReliabilityStatistics) == 8880);
 
 // Seagate Field Access Reliability Metrics log (FARM) all pages
 #pragma pack(1)
@@ -840,7 +853,7 @@ struct ataFarmLogFrame {
 	ataFarmReliabilityStatistics        reliabilityPage;        // Reliability Statistics page
 } ATTR_PACKED;
 #pragma pack()
-STATIC_ASSERT(sizeof(ataFarmLogFrame) == 64 + 368 + 168 + 432 + 256 + 6760);
+STATIC_ASSERT(sizeof(ataFarmLogFrame) == 72 + 376 + 168 + 952 + 256 + 8880);
 
 // Possible values for span_args.mode
 enum {

--- a/smartmontools/atacmds.h
+++ b/smartmontools/atacmds.h
@@ -604,7 +604,7 @@ STATIC_ASSERT(sizeof(ata_sct_temperature_history_table) == 512);
 // Seagate Field Access Reliability Metrics log (FARM) page 0 (read with ATA_READ_LOG_EXT address 0xa6, page 0)
 // Log Header
 #pragma pack(1)
-typedef struct ataFarmHeader {
+struct ataFarmHeader {
 	uint64_t        signature;        // Log signature = 0x00004641524D4552
 	uint64_t        majorRev;         // Log major revision
 	uint64_t        minorRev;         // Log minor revision
@@ -620,7 +620,7 @@ STATIC_ASSERT(sizeof(ataFarmHeader) == 64);
 // Seagate Field Access Reliability Metrics log (FARM) page 1 (read with ATA_READ_LOG_EXT address 0xa6, page 1)
 // Drive Information
 #pragma pack(1)
-typedef struct ataFarmDriveInformation {
+struct ataFarmDriveInformation {
 	uint64_t        pageNumber;           // Page Number = 1
 	uint64_t        copyNumber;           // Copy Number
 	uint64_t        serialNumber;         // Serial Number
@@ -665,7 +665,7 @@ STATIC_ASSERT(sizeof(ataFarmDriveInformation) == 368);
 // Seagate Field Access Reliability Metrics log (FARM) page 2 (read with ATA_READ_LOG_EXT address 0xa6, page 2)
 // Workload Statistics
 #pragma pack(1)
-typedef struct ataFarmWorkloadStatistics {
+struct ataFarmWorkloadStatistics {
 	uint64_t        pageNumber;               // Page Number = 2
 	uint64_t        copyNumber;               // Copy Number
 	uint64_t        workloadPercentage;       // Rated Workload Percentage
@@ -694,7 +694,7 @@ STATIC_ASSERT(sizeof(ataFarmWorkloadStatistics) == 168);
 // Seagate Field Access Reliability Metrics log (FARM) page 3 (read with ATA_READ_LOG_EXT address 0xa6, page 3)
 // Error Statistics
 #pragma pack(1)
-typedef struct ataFarmErrorStatistics {
+struct ataFarmErrorStatistics {
 	uint64_t         pageNumber;                          // Page Number = 3
 	uint64_t         copyNumber;                          // Copy Number
 	uint64_t         totalReadECC;                        // Number of Unrecoverable Read Errors
@@ -727,7 +727,7 @@ STATIC_ASSERT(sizeof(ataFarmErrorStatistics) == 432);
 // Seagate Field Access Reliability Metrics log (FARM) page 4 (read with ATA_READ_LOG_EXT address 0xa6, page 4)
 // Environment Statistics
 #pragma pack(1)
-typedef struct ataFarmEnvironmentStatistics {
+struct ataFarmEnvironmentStatistics {
 	uint64_t         pageNumber;          // Page Number = 4
 	uint64_t         copyNumber;          // Copy Number
 	uint64_t         curentTemp;          // Current Temperature in Celsius
@@ -767,7 +767,7 @@ STATIC_ASSERT(sizeof(ataFarmEnvironmentStatistics) == 256);
 // Seagate Field Access Reliability Metrics log (FARM) page 5 (read with ATA_READ_LOG_EXT address 0xa6, page 5)
 // Reliability Statistics
 #pragma pack(1)
-typedef struct ataFarmReliabilityStatistics {
+struct ataFarmReliabilityStatistics {
 	int64_t         pageNumber;                         // Page Number = 5
 	int64_t         copyNumber;                         // Copy Number
 	int64_t         lastIDDTest;                        // Timestamp of last IDD test
@@ -831,7 +831,7 @@ STATIC_ASSERT(sizeof(ataFarmReliabilityStatistics) == 6760);
 
 // Seagate Field Access Reliability Metrics log (FARM) all pages
 #pragma pack(1)
-typedef struct ataFarmLogFrame {
+struct ataFarmLogFrame {
   ataFarmHeader                       headerPage;             // Log Header page
 	ataFarmDriveInformation             driveInformationPage;   // Drive Information page
 	ataFarmWorkloadStatistics           workloadPage;           // Workload Statistics page

--- a/smartmontools/atacmds.h
+++ b/smartmontools/atacmds.h
@@ -604,7 +604,7 @@ STATIC_ASSERT(sizeof(ata_sct_temperature_history_table) == 512);
 // Seagate Field Access Reliability Metrics log (FARM) page 0 (read with ATA_READ_LOG_EXT address 0xa6, page 0)
 // Log Header
 #pragma pack(1)
-struct ataFarmHeader {
+typedef struct ataFarmHeader {
 	uint64_t        signature;        // Log signature = 0x00004641524D4552
 	uint64_t        majorRev;         // Log major revision
 	uint64_t        minorRev;         // Log minor revision
@@ -620,7 +620,7 @@ STATIC_ASSERT(sizeof(ataFarmHeader) == 64);
 // Seagate Field Access Reliability Metrics log (FARM) page 1 (read with ATA_READ_LOG_EXT address 0xa6, page 1)
 // Drive Information
 #pragma pack(1)
-struct ataFarmDriveInformation {
+typedef struct ataFarmDriveInformation {
 	uint64_t        pageNumber;           // Page Number = 1
 	uint64_t        copyNumber;           // Copy Number
 	uint64_t        serialNumber;         // Serial Number
@@ -665,7 +665,7 @@ STATIC_ASSERT(sizeof(ataFarmDriveInformation) == 368);
 // Seagate Field Access Reliability Metrics log (FARM) page 2 (read with ATA_READ_LOG_EXT address 0xa6, page 2)
 // Workload Statistics
 #pragma pack(1)
-struct ataFarmWorkloadStatistics {
+typedef struct ataFarmWorkloadStatistics {
 	uint64_t        pageNumber;               // Page Number = 2
 	uint64_t        copyNumber;               // Copy Number
 	uint64_t        workloadPercentage;       // Rated Workload Percentage
@@ -694,7 +694,7 @@ STATIC_ASSERT(sizeof(ataFarmWorkloadStatistics) == 168);
 // Seagate Field Access Reliability Metrics log (FARM) page 3 (read with ATA_READ_LOG_EXT address 0xa6, page 3)
 // Error Statistics
 #pragma pack(1)
-struct ataFarmErrorStatistics {
+typedef struct ataFarmErrorStatistics {
 	uint64_t         pageNumber;                          // Page Number = 3
 	uint64_t         copyNumber;                          // Copy Number
 	uint64_t         totalReadECC;                        // Number of Unrecoverable Read Errors
@@ -727,7 +727,7 @@ STATIC_ASSERT(sizeof(ataFarmErrorStatistics) == 432);
 // Seagate Field Access Reliability Metrics log (FARM) page 4 (read with ATA_READ_LOG_EXT address 0xa6, page 4)
 // Environment Statistics
 #pragma pack(1)
-struct ataFarmEnvironmentStatistics {
+typedef struct ataFarmEnvironmentStatistics {
 	uint64_t         pageNumber;          // Page Number = 4
 	uint64_t         copyNumber;          // Copy Number
 	uint64_t         curentTemp;          // Current Temperature in Celsius
@@ -767,7 +767,7 @@ STATIC_ASSERT(sizeof(ataFarmEnvironmentStatistics) == 256);
 // Seagate Field Access Reliability Metrics log (FARM) page 5 (read with ATA_READ_LOG_EXT address 0xa6, page 5)
 // Reliability Statistics
 #pragma pack(1)
-struct ataFarmReliabilityStatistics {
+typedef struct ataFarmReliabilityStatistics {
 	int64_t         pageNumber;                         // Page Number = 5
 	int64_t         copyNumber;                         // Copy Number
 	int64_t         lastIDDTest;                        // Timestamp of last IDD test

--- a/smartmontools/atacmds.h
+++ b/smartmontools/atacmds.h
@@ -601,6 +601,247 @@ struct ata_sct_temperature_history_table
 #pragma pack()
 STATIC_ASSERT(sizeof(ata_sct_temperature_history_table) == 512);
 
+// Seagate Field Access Reliability Metrics log (FARM) page 0 (read with ATA_READ_LOG_EXT address 0xa6, page 0)
+// Log Header
+#pragma pack(1)
+struct ataFarmHeader {
+	uint64_t        signature;        // Log signature = 0x00004641524D4552
+	uint64_t        majorRev;         // Log major revision
+	uint64_t        minorRev;         // Log minor revision
+	uint64_t        pagesSupported;   // Number of pages supported
+	uint64_t        logSize;          // Log size in bytes
+	uint64_t        pageSize;         // Page size in bytes
+	uint64_t        headsSupported;   // Maximum drive heads supported
+	uint64_t        copies;           // Number of historical copies
+} ATTR_PACKED;
+#pragma pack()
+STATIC_ASSERT(sizeof(ataFarmHeader) == 64);
+
+// Seagate Field Access Reliability Metrics log (FARM) page 1 (read with ATA_READ_LOG_EXT address 0xa6, page 1)
+// Drive Information
+#pragma pack(1)
+struct ataFarmDriveInformation {
+	uint64_t        pageNumber;           // Page Number = 1
+	uint64_t        copyNumber;           // Copy Number
+	uint64_t        serialNumber;         // Serial Number
+	uint64_t        serialNumber2;        // Serial Number 2
+	uint64_t        worldWideName;        // World Wide Name 
+	uint64_t        worldWideName2;       // World Wide Name 2
+	uint64_t        deviceInterface;      // Device Interface
+	uint64_t        deviceCapacity;       // 48-bit Device Capacity
+	uint64_t        psecSize;             // Physical Sector Size in Bytes
+	uint64_t        lsecSize;             // Logical Sector Size in Bytes
+	uint64_t        deviceBufferSize;     // Device Buffer Size in Bytes
+	uint64_t        heads;                // Number of Heads
+	uint64_t        factor;               // Device Form Factor (ID Word 168)
+	uint64_t        rotationRate;         // Rotational Rate of Device (ID Word 217)
+	uint64_t        firmware;             // Firmware 
+	uint64_t        firmwareRev;          // Firmware Revision
+	uint64_t        security;             // ATA Security State (ID Word 128)
+	uint64_t        featuresSupported;    // ATA Features Supported (ID Word 78)
+	uint64_t        featuresEnabled;      // ATA Features Enabled (ID Word 79)
+	uint64_t        poh;                  // Power-On Hours
+	uint64_t        spoh;                 // Spindle Power-On Hours
+	uint64_t        headFlightHours;      // Head Flight Hours
+	uint64_t        headLoadEvents;       // Head Load Events
+	uint64_t        powerCycleCount;      // Power Cycle Count
+	uint64_t        resetCount;           // Hardware Reset Count
+	uint64_t        spinUpTime;           // SMART Spin-Up Time in milliseconds
+	uint64_t        NVC_StatusATPowerOn;  // NVC Status on Power-On
+	uint64_t        timeAvailable;        // Time Available to Save User Data to Media Over Last Power Cycle (in 100us)
+	uint64_t        timeStamp1;           // Timestamp of latest SMART Summary Frame in Power-On Hours Milliseconds
+	uint64_t        timeStamp2;           // Timestamp of latest SMART Summary Frame in Power-On Hours Milliseconds
+	uint64_t        timeToReady;					// Time to ready of the last power cycle
+	uint64_t        timeHeld;							// Time drive is held in staggered spin during the last power on sequence
+  uint64_t        modelNumber[10];      // Lower 32 Model Number (added 2.14)
+  uint64_t        driveRecordingType;   // 0 for SMR and 1 for CMR (added 2.15)
+  uint64_t        depopped;             // Has the drive been depopped  1 = depopped and 0 = not depopped (added 2.15)
+  uint64_t        maxNumberForReasign;  // Max Number of Available Sectors for Reassignment – Value in disc sectors (added 3.3)
+  uint64_t        dateOfAssembly;       // Date of assembly in ASCII “YYWW” where YY is the year and WW is the calendar week (added 4.2)
+} ATTR_PACKED;
+#pragma pack()
+STATIC_ASSERT(sizeof(ataFarmDriveInformation) == 368);
+
+// Seagate Field Access Reliability Metrics log (FARM) page 2 (read with ATA_READ_LOG_EXT address 0xa6, page 2)
+// Workload Statistics
+#pragma pack(1)
+struct ataFarmWorkloadStatistics {
+	uint64_t        pageNumber;               // Page Number = 2
+	uint64_t        copyNumber;               // Copy Number
+	uint64_t        workloadPercentage;       // Rated Workload Percentage
+	uint64_t        totalReadCommands;        // Total Number of Read Commands
+	uint64_t        totalWriteCommands;       // Total Number of Write Commands
+	uint64_t        totalRandomReads;         // Total Number of Random Read Commands
+	uint64_t        totalRandomWrites;        // Total Number of Random Write Commands
+	uint64_t        totalNumberofOtherCMDS;   // Total Number Of Other Commands
+	uint64_t        logicalSecWritten;        // Logical Sectors Written
+	uint64_t        logicalSecRead;           // Logical Sectors Read
+  uint64_t        dither;                   // Number of dither events during current power cycle (added 3.4)
+  uint64_t        ditherRandom;             // Number of times dither was held off during random workloads during current power cycle (added 3.4)
+  uint64_t        ditherSequential;         // Number of times dither was held off during sequential workloads during current power cycle (added 3.4) 
+  uint64_t        readCommandsByRadius1;    // Number of Read Commands from 0-3.125% of LBA space for last 3 SMART Summary Frames (added 4.4)
+  uint64_t        readCommandsByRadius2;    // Number of Read Commands from 3.125-25% of LBA space for last 3 SMART Summary Frames (added 4.4)
+  uint64_t        readCommandsByRadius3;    // Number of Read Commands from 25-75% of LBA space for last 3 SMART Summary Frames (added 4.4)
+  uint64_t        readCommandsByRadius4;    // Number of Read Commands from 75-100% of LBA space for last 3 SMART Summary Frames (added 4.4)
+  uint64_t        writeCommandsByRadius1;   // Number of Write Commands from 0-3.125% of LBA space for last 3 SMART Summary Frames (added 4.4)
+  uint64_t        writeCommandsByRadius2;   // Number of Write Commands from 3.125-25% of LBA space for last 3 SMART Summary Frames (added 4.4)
+  uint64_t        writeCommandsByRadius3;   // Number of Write Commands from 25-75% of LBA space for last 3 SMART Summary Frames (added 4.4)
+  uint64_t        writeCommandsByRadius4;   // Number of Write Commands from 75-100% of LBA space for last 3 SMART Summary Frames (added 4.4)
+} ATTR_PACKED;
+#pragma pack()
+STATIC_ASSERT(sizeof(ataFarmWorkloadStatistics) == 168);
+
+// Seagate Field Access Reliability Metrics log (FARM) page 3 (read with ATA_READ_LOG_EXT address 0xa6, page 3)
+// Error Statistics
+#pragma pack(1)
+struct ataFarmErrorStatistics {
+	uint64_t         pageNumber;                          // Page Number = 3
+	uint64_t         copyNumber;                          // Copy Number
+	uint64_t         totalReadECC;                        // Number of Unrecoverable Read Errors
+	uint64_t         totalWriteECC;                       // Number of Unrecoverable Write Errors
+	uint64_t         totalReallocations;                  // Number of Reallocated Sectors
+	uint64_t         totalReadRecoveryAttepts;            // Number of Read Recovery Attempts
+	uint64_t         totalMechanicalFails;                // Number of Mechanical Start Failures
+	uint64_t         totalReallocatedCanidates;           // Number of Re-allocated Candidate Sectors
+	uint64_t         totalASREvents;                      // Number of ASR Events
+	uint64_t         totalCRCErrors;                      // Number of Interface CRC Errors
+	uint64_t         attrSpinRetryCount;                  // Spin Retry Count 
+	uint64_t         normalSpinRetryCount;                // Spin Retry Count 
+	uint64_t         worstSpinRretryCount;                // Spin Retry Count 
+	uint64_t         attrIOEDCErrors;                     // Number of IOEDC Errors 
+	uint64_t         attrCTOCount;                        // CTO Count Total 
+	uint64_t         overfiveSecCTO;                      // CTO Count Over 5s 
+	uint64_t         oversevenSecCTO;                     // CTO Count Over 7.5s 
+	uint64_t         totalFlashLED;                       // Total Flash LED (Assert) Events
+	uint64_t         indexFlashLED;                       // Index of the last Flash LED of the array
+	uint64_t         uncorrectables;                      // Uncorrectable errors (SMART Attribute 187 Raw)
+  uint64_t         smartTrip;                           // FRU code if SMART trip from most recent SMART Frame (SAS Only) 
+	uint64_t         flashLEDArray[8];                    // Info on the last 8 Flash LED (assert) events wrapping array (added 2.7)
+  uint64_t         readWriteRetry[8];                   // Info on the last 8 read/write retry events (added 2.7)
+  uint64_t         superParityOnTheFlyRecoveryCnt[2];   // Super Parity on the Fly Recovery counters  (added 3.0)
+  uint64_t         reallocatedSectors[15];              // Re-allocated Sectors by cause (added 3.0)
+} ATTR_PACKED;
+#pragma pack()
+STATIC_ASSERT(sizeof(ataFarmErrorStatistics) == 432);
+
+// Seagate Field Access Reliability Metrics log (FARM) page 4 (read with ATA_READ_LOG_EXT address 0xa6, page 4)
+// Environment Statistics
+#pragma pack(1)
+struct ataFarmEnvironmentStatistics {
+	uint64_t         pageNumber;          // Page Number = 4
+	uint64_t         copyNumber;          // Copy Number
+	uint64_t         curentTemp;          // Current Temperature in Celsius
+	uint64_t         highestTemp;         // Highest Temperature in Celsius
+	uint64_t         lowestTemp;          // Lowest Temperature
+	uint64_t         averageTemp;         // Average Short-Term Temperature
+	uint64_t         averageLongTemp;     // Average Long-Term Temperature
+	uint64_t         highestShortTemp;    // Highest Average Short-Term Temperature
+	uint64_t         lowestShortTemp;     // Lowest Average Short-Term Temperature
+	uint64_t         highestLongTemp;     // Highest Average Long-Term Temperature
+	uint64_t         lowestLongTemp;      // Lowest Average Long-Term Temperature
+	uint64_t         overTempTime;        // Time In Over Temperature
+	uint64_t         underTempTime;       // Time In Under Temperature
+	uint64_t         maxTemp;             // Specified Max Operating Temperature
+	uint64_t         minTemp;             // Specified Min Operating Temperature
+	uint64_t         shockEvents;         // Over-Limit Shock Events Count
+	uint64_t         hfWriteCounts;       // High Fly Write Count 
+	uint64_t         humidity;            // Current Relative Humidity (in units of 0.1%)
+	uint64_t         humidityRatio;       // Humidity Mixed Ratio multiplied by 8 (divide by 8 to get actual value)
+	uint64_t         currentMotorPower;   // Current Motor Power, value from most recent SMART Summary Frame
+  uint64_t         current12v;          // Current 12V input (added 3.7)
+  uint64_t         min12v;              // Minimum 12V input from last 3 SMART Summary Frames (added 3.7)
+  uint64_t         max12v;              // Maximum 12V input from last 3 SMART Summary Frames (added 3.7)
+  uint64_t         current5v;           // Current 5V input (added 3.7)
+  uint64_t         min5v;               // Minimum 5V input from last 3 SMART Summary Frames (added 3.7)
+  uint64_t         max5v;               // Maximum 5V input from last 3 SMART Summary Frames (added 3.7)
+  uint64_t         powerAverage12v;     // 12V Power Average (mW) - Average of last 3 SMART Summary Frames (added 4.3)
+  uint64_t         powerMin12v;         // 12V Power Min (mW) - Lowest of last 3 SMART Summary Frames (added 4.3)
+  uint64_t         powerMax12v;         // 12V Power Max (mW) - Highest of last 3 SMART Summary Frames (added 4.3)
+  uint64_t         powerAverage5v;      // 5V Power Average (mW) - Average of last 3 SMART Summary Frames (added 4.3)
+  uint64_t         powerMin5v;          // 5V Power Min (mW) - Lowest of last 3 SMART Summary Frames (added 4.3)
+  uint64_t         powerMax5v;          // 5V Power Max (mW) - Highest of last 3 SMART Summary Frames (added 4.3)
+} ATTR_PACKED;
+#pragma pack()
+STATIC_ASSERT(sizeof(ataFarmEnvironmentStatistics) == 256);
+
+// Seagate Field Access Reliability Metrics log (FARM) page 5 (read with ATA_READ_LOG_EXT address 0xa6, page 5)
+// Reliability Statistics
+#pragma pack(1)
+struct ataFarmReliabilityStatistics {
+	int64_t         pageNumber;                         // Page Number = 5
+	int64_t         copyNumber;                         // Copy Number
+	int64_t         lastIDDTest;                        // Timestamp of last IDD test
+	int64_t         cmdLastIDDTest;                     // Sub-command of last IDD test
+  uint64_t        discSlip[24];                       // [24] Disc Slip in micro-inches by Head
+  uint64_t        bitErrorRate[24];                   // [24] Bit Error Rate of Zone 0 by Drive Head
+	int64_t         gListReclamed;                      // Number of G-List Reclamations 
+	int64_t         servoStatus;                        // Servo Status (follows standard DST error code definitions)
+	int64_t         altsBeforeIDD;                      // Number of Alt List Entries Before IDD Scan
+	int64_t         altsAfterIDD;                       // Number of Alt List Entries After IDD Scan
+	int64_t         gListBeforIDD;                      // Number of Resident G-List Entries Before IDD Scan
+	int64_t         gListAfterIDD;                      // Number of Resident G-List Entries After IDD Scan
+	int64_t         scrubsBeforeIDD;                    // Number of Scrub List Entries Before IDD Scan
+	int64_t         scrubsAfterIDD;                     // Number of Scrub List Entries After IDD Scan
+	int64_t         numberDOSScans;                     // Number of DOS Scans Performed
+	int64_t         numberLBACorrect;                   // Number of LBAs Corrected by ISP
+	int64_t         numberValidParitySec;               // Number of Valid Parity Sectors
+	int64_t         dosWriteCount[24];                  // [24] DOS Write Refresh Count
+	int64_t         numberRAWops;                       // Number of RAW Operations
+	int64_t         DVGASkipWriteDetect[24];            // [24] DVGA Skip Write Detect by Head
+	int64_t         RVGASkipWriteDetect[24];            // [24] RVGA Skip Write Detect by Head
+	int64_t         FVGASkipWriteDetect[24];            // [24] FVGA Skip Write Detect by Head
+	int64_t         skipWriteDetectThresExceeded[24];   // [24] Skip Write Detect Threshold Exceeded Count by Head
+	int64_t         attrErrorRateRaw;                   // Error Rate Raw
+	int64_t         attrErrorRateNormal;                // Error Rate Normalized
+	int64_t         attrErrorRateWorst;                 // Error Rate Worst
+	int64_t         attrSeekErrorRateRaw;               // Seek Error Rate Raw
+	int64_t         attrSeekErrorRateNormal;            // Seek Error Rate Normalized
+	int64_t         attrSeekErrorRateWorst;             // Seek Error Rate Worst
+	int64_t         attrUnloadEventsRaw;                // High Priority Unload Events 
+	uint64_t        microActuatorLockOut;               // Micro Actuator Lock-out, head mask accumulated over last 3 Summary Frames
+	int64_t         sineACFF[24];                       // [24] ACFF Sine 1X, value from most recent SMART Summary Frame by Head
+	int64_t         cosineACFF[24];                     // [24] ACFF Cosine 1X, value from most recent SMART Summary Frame by Head
+	int64_t         PZTCalibration[24];                 // [24] PZT Calibration, value from most recent SMART Summary Frame by Head
+	int64_t         MRHeadResistance[24];               // [24] MR Head Resistance from most recent SMART Summary Frame by Head
+	int64_t         numberOfTMD[24];                    // [24] Number of TMD over last 3 SMART Summary Frames by Head
+	int64_t         velocityObserver[24];               // [24] Velocity Observer over last 3 SMART Summary Frames by Head
+	int64_t         numberOfVelocityObserver[24];       // [24] Number of Velocity Observer over last 3 SMART Summary Frames by Head
+	int64_t         currentH2SAT[24][3];                // [24][3] Current H2SAT trimmed mean bits in error by Head, by Test Zone 
+	int64_t         currentH2SATIterations[24][3];      // [24][3] Current H2SAT iterations to converge by Head, by Test Zone 
+	int64_t         currentH2SATPercentage[24];         // [24] Current H2SAT percentage of codewords at iteration level by Head, averaged
+	int64_t         currentH2SATAmplitude[24];          // [24] Qword[24] Current H2SAT amplitude by Head, averaged across Test Zones 
+	int64_t         currentH2SATAsymmetry[24];          // [24] Qword[24] Current H2SAT asymmetry by Head, averaged across Test Zones
+	int64_t         flyHeightClearance[24][3];          // [24][3] Applied fly height clearance delta per head in thousandths of one Angstrom
+	int64_t         diskSlipRecalPerformed;             // Number of disc slip recalibrations performed
+	int64_t         gList[24];                          // [24] Number of Resident G-List per Head
+	int64_t         pendingEntries[24];                 // [24] Number of pending Entries per Head
+	int64_t         heliumPresureTrip;                  // Helium Pressure Threshold Tripped ( 1- trip, 0 -no trip)
+	int64_t         oughtDOS[24];                       // [24] DOS Ought to scan count per head
+	int64_t         needDOS[24];                        // [24] DOS needs to scanns count per head
+	int64_t         writeDOSFault[24];                  // [24] DOS  write Fault scans per head
+	int64_t         writePOH[24];                       // [24] Write POS in sec value from most recent SMART Frame by head
+	int64_t         RVAbsoluteMean;                     // RV Absolute Mean, value from the most recent SMART Frame
+	int64_t         maxRVAbsoluteMean;                  // Max RV Absolute Mean, value from the most recent SMART Summary Frame
+	int64_t         idleTime;                           // Idle Time, Value from most recent SMART Summary Frame
+	int64_t         countDOSWrite[24];                  // [24] DOS Write Count Threshold per head
+  int64_t         secondMRHeadResistance[24];         // [24] Second Head, MR Head Resistance from most recent SMART Summary Frame by Head (added 2.11)
+} ATTR_PACKED;
+#pragma pack()
+STATIC_ASSERT(sizeof(ataFarmReliabilityStatistics) == 6760);
+
+// Seagate Field Access Reliability Metrics log (FARM) all pages
+#pragma pack(1)
+typedef struct ataFarmLogFrame {
+  ataFarmHeader                       headerPage;             // Log Header page
+	ataFarmDriveInformation             driveInformationPage;   // Drive Information page
+	ataFarmWorkloadStatistics           workloadPage;           // Workload Statistics page
+	ataFarmErrorStatistics              errorPage;              // Error Statistics page
+	ataFarmEnvironmentStatistics        environmentPage;        // Environment Statistics page 
+	ataFarmReliabilityStatistics        reliabilityPage;        // Reliability Statistics page
+} ATTR_PACKED;
+#pragma pack()
+STATIC_ASSERT(sizeof(ataFarmLogFrame) == 64 + 368 + 168 + 432 + 256 + 6760);
+
 // Possible values for span_args.mode
 enum {
   SEL_RANGE, // MIN-MAX

--- a/smartmontools/atacmds.h
+++ b/smartmontools/atacmds.h
@@ -649,9 +649,9 @@ struct ataFarmDriveInformation {
 	uint64_t        resetCount;             // Hardware Reset Count
 	uint64_t        spinUpTime;             // SMART Spin-Up Time in milliseconds
 	uint64_t        reserved;               // Reserved
-	uint64_t        reserved;               // Reserved
-	uint64_t        reserved;               // Reserved
-	uint64_t        reserved;               // Reserved
+	uint64_t        reserved0;              // Reserved
+	uint64_t        reserved1;              // Reserved
+	uint64_t        reserved2;              // Reserved
 	uint64_t        timeToReady;			      // Time to ready of the last power cycle
 	uint64_t        timeHeld;					      // Time drive is held in staggered spin during the last power on sequence
   uint64_t        modelNumber[10];        // Lower 32 Model Number (added 2.14)
@@ -719,9 +719,9 @@ struct ataFarmErrorStatistics {
 	uint64_t        uncorrectables;                             // Uncorrectable errors (SMART Attribute 187 Raw)
   uint64_t        reserved;                                   // Reserved
   uint64_t        flashLEDArray[8];                           // Info on the last 8 Flash LED (assert) events wrapping array (added 2.7)
-  uint64_t        reserved[8];                                // Reserved
-  uint64_t        reserved[2];                                // Reserved
-  uint64_t        reserved[15];                               // Reserved
+  uint64_t        reserved0[8];                               // Reserved
+  uint64_t        reserved1[2];                               // Reserved
+  uint64_t        reserved2[15];                              // Reserved
   uint64_t        universalTimestampFlashLED[8];              // Universal Timestamp (us) of last 8 Flash LED (assert) Events, wrapping array
   uint64_t        powerCycleFlashLED[8];                      // Power Cycle of the last 8 Flash LED (assert) Events, wrapping array
   uint64_t        cumulativeUnrecoverableReadERC;             // Cumulative Lifetime Unrecoverable Read errors due to Error Recovery Control (e.g. ERC timeout)
@@ -751,9 +751,9 @@ struct ataFarmEnvironmentStatistics {
 	uint64_t         maxTemp;             // Specified Max Operating Temperature in Celsius
 	uint64_t         minTemp;             // Specified Min Operating Temperature in Celsius
 	uint64_t         reserved;            // Reserved
-	uint64_t         reserved;            // Reserved
+	uint64_t         reserved0;           // Reserved
 	uint64_t         humidity;            // Current Relative Humidity (in units of 0.1%)
-	uint64_t         reserved;            // Reserved
+	uint64_t         reserved1;           // Reserved
 	uint64_t         currentMotorPower;   // Current Motor Power, value from most recent SMART Summary Frame
   uint64_t         current12v;          // Current 12V input (added 3.7)
   uint64_t         min12v;              // Minimum 12V input from last 3 SMART Summary Frames in mV (added 3.7)
@@ -778,22 +778,22 @@ struct ataFarmReliabilityStatistics {
 	int64_t         pageNumber;                         // Page Number = 5
 	int64_t         copyNumber;                         // Copy Number
 	uint64_t        reserved;                           // Reserved
-	uint64_t        reserved;                           // Reserved
-  uint64_t        reserved[24];                       // Reserved
-  uint64_t        reserved[24];                       // Reserved
-	uint64_t        reserved;                           // Reserved
-	uint64_t        reserved;                           // Reserved
-	uint64_t        reserved;                           // Reserved
-	uint64_t        reserved;                           // Reserved
-	uint64_t        reserved;                           // Reserved
-	uint64_t        reserved;                           // Reserved
-	uint64_t        reserved;                           // Reserved
-	uint64_t        reserved;                           // Reserved
-	uint64_t        reserved;                           // Reserved
-	uint64_t        reserved;                           // Reserved
-	uint64_t        reserved;                           // Reserved
-	uint64_t        reserved[24];                       // Reserved
-	uint64_t        reserved;                           // Reserved
+	uint64_t        reserved0;                          // Reserved
+  uint64_t        reserved1[24];                      // Reserved
+  uint64_t        reserved2[24];                      // Reserved
+	uint64_t        reserved3;                          // Reserved
+	uint64_t        reserved4;                          // Reserved
+	uint64_t        reserved5;                          // Reserved
+	uint64_t        reserved6;                          // Reserved
+	uint64_t        reserved7;                          // Reserved
+	uint64_t        reserved8;                          // Reserved
+	uint64_t        reserved9;                          // Reserved
+	uint64_t        reserved10;                         // Reserved
+	uint64_t        reserved11;                         // Reserved
+	uint64_t        reserved12;                         // Reserved
+	uint64_t        reserved13;                         // Reserved
+	uint64_t        reserved14[24];                     // Reserved
+	uint64_t        reserved15;                         // Reserved
 	int64_t         DVGASkipWriteDetect[24];            // [24] DVGA Skip Write Detect by Head
 	int64_t         RVGASkipWriteDetect[24];            // [24] RVGA Skip Write Detect by Head
 	int64_t         FVGASkipWriteDetect[24];            // [24] FVGA Skip Write Detect by Head
@@ -805,38 +805,38 @@ struct ataFarmReliabilityStatistics {
 	int64_t         attrSeekErrorRateNormal;            // Seek Error Rate Normalized
 	int64_t         attrSeekErrorRateWorst;             // Seek Error Rate Worst
 	int64_t         attrUnloadEventsRaw;                // High Priority Unload Events 
-	uint64_t        reserved;                           // Reserved
-	uint64_t        reserved[24];                       // Reserved
-	uint64_t        reserved[24];                       // Reserved
-	uint64_t        reserved[24];                       // Reserved
-	uint64_t        reserved[24];                       // Reserved
-	uint64_t        reserved[24];                       // Reserved
-	uint64_t        reserved[24];                       // Reserved
-	uint64_t        reserved[24];                       // Reserved
-	uint64_t        reserved[24][3];                    // Reserved
-	uint64_t        reserved[24][3];                    // Reserved
-	uint64_t        reserved[24];                       // Reserved
-	uint64_t        reserved[24];                       // Reserved
-	uint64_t        reserved[24];                       // Reserved
-	uint64_t        reserved[24][3];                    // Reserved
-	uint64_t        reserved;                           // Reserved
+	uint64_t        reserved16;                         // Reserved
+	uint64_t        reserved17[24];                     // Reserved
+	uint64_t        reserved18[24];                     // Reserved
+	uint64_t        reserved19[24];                     // Reserved
+	uint64_t        reserved20[24];                     // Reserved
+	uint64_t        reserved21[24];                     // Reserved
+	uint64_t        reserved22[24];                     // Reserved
+	uint64_t        reserved23[24];                     // Reserved
+	uint64_t        reserved24[24][3];                  // Reserved
+	uint64_t        reserved25[24][3];                  // Reserved
+	uint64_t        reserved26[24];                     // Reserved
+	uint64_t        reserved27[24];                     // Reserved
+	uint64_t        reserved28[24];                     // Reserved
+	uint64_t        reserved29[24][3];                  // Reserved
+	uint64_t        reserved30;                         // Reserved
 	int64_t         reallocatedSectors[24];             // [24] Number of Reallocated Sectors per Head
 	int64_t         reallocationCandidates[24];         // [24] Number of Reallocation Candidate Sectors per Head
 	int64_t         heliumPresureTrip;                  // Helium Pressure Threshold Tripped ( 1 - trip, 0 - no trip)
-  uint64_t        reserved[24];                       // Reserved
-  uint64_t        reserved[24];                       // Reserved
-  uint64_t        reserved[24];                       // Reserved
+  uint64_t        reserved31[24];                     // Reserved
+  uint64_t        reserved31[24];                     // Reserved
+  uint64_t        reserved32[24];                     // Reserved
 	int64_t         writeWorkloadPowerOnTime[24];       // [24] Write Workload Power-on Time in Seconds, value from most recent SMART Summary Frame by Head
-	uint64_t        reserved;                           // Reserved
-	uint64_t        reserved;                           // Reserved
-	uint64_t        reserved;                           // Reserved
-  uint64_t        reserved[24];                       // Reserved
+	uint64_t        reserved33;                         // Reserved
+	uint64_t        reserved34;                         // Reserved
+	uint64_t        reserved35;                         // Reserved
+  uint64_t        reserved36[24];                     // Reserved
   int64_t         secondMRHeadResistance[24];         // [24] Second Head, MR Head Resistance from most recent SMART Summary Frame by Head
-  uint64_t        reserved[24];                       // Reserved
-  uint64_t        reserved[24];                       // Reserved
-  uint64_t        reserved[24][3];                    // Reserved
-  uint64_t        reserved[24][3];                    // Reserved
-  uint64_t        reserved[24][3];                    // Reserved
+  uint64_t        reserved37[24];                     // Reserved
+  uint64_t        reserved38[24];                     // Reserved
+  uint64_t        reserved39[24][3];                  // Reserved
+  uint64_t        reserved40[24][3];                  // Reserved
+  uint64_t        reserved41[24][3];                  // Reserved
 	int64_t         numberLBACorrectedParitySector;     // Number of LBAs Corrected by Parity Sector
 } ATTR_PACKED;
 #pragma pack()

--- a/smartmontools/atacmds.h
+++ b/smartmontools/atacmds.h
@@ -824,19 +824,19 @@ struct ataFarmReliabilityStatistics {
 	int64_t         reallocationCandidates[24];         // [24] Number of Reallocation Candidate Sectors per Head
 	int64_t         heliumPresureTrip;                  // Helium Pressure Threshold Tripped ( 1 - trip, 0 - no trip)
   uint64_t        reserved31[24];                     // Reserved
-  uint64_t        reserved31[24];                     // Reserved
   uint64_t        reserved32[24];                     // Reserved
+  uint64_t        reserved33[24];                     // Reserved
 	int64_t         writeWorkloadPowerOnTime[24];       // [24] Write Workload Power-on Time in Seconds, value from most recent SMART Summary Frame by Head
-	uint64_t        reserved33;                         // Reserved
 	uint64_t        reserved34;                         // Reserved
 	uint64_t        reserved35;                         // Reserved
-  uint64_t        reserved36[24];                     // Reserved
-  int64_t         secondMRHeadResistance[24];         // [24] Second Head, MR Head Resistance from most recent SMART Summary Frame by Head
+	uint64_t        reserved36;                         // Reserved
   uint64_t        reserved37[24];                     // Reserved
+  int64_t         secondMRHeadResistance[24];         // [24] Second Head, MR Head Resistance from most recent SMART Summary Frame by Head
   uint64_t        reserved38[24];                     // Reserved
-  uint64_t        reserved39[24][3];                  // Reserved
+  uint64_t        reserved39[24];                     // Reserved
   uint64_t        reserved40[24][3];                  // Reserved
   uint64_t        reserved41[24][3];                  // Reserved
+  uint64_t        reserved42[24][3];                  // Reserved
 	int64_t         numberLBACorrectedParitySector;     // Number of LBAs Corrected by Parity Sector
 } ATTR_PACKED;
 #pragma pack()

--- a/smartmontools/atacmds.h
+++ b/smartmontools/atacmds.h
@@ -699,7 +699,7 @@ struct ataFarmErrorStatistics {
 	uint64_t         copyNumber;                          // Copy Number
 	uint64_t         totalReadECC;                        // Number of Unrecoverable Read Errors
 	uint64_t         totalWriteECC;                       // Number of Unrecoverable Write Errors
-	uint64_t         totalReallocations;                  // Number of Reallocated Sectors
+	uint64_t         totalReallocations;                  // Number of Re-allocated Sectors
 	uint64_t         totalReadRecoveryAttepts;            // Number of Read Recovery Attempts
 	uint64_t         totalMechanicalFails;                // Number of Mechanical Start Failures
 	uint64_t         totalReallocatedCanidates;           // Number of Re-allocated Candidate Sectors

--- a/smartmontools/atacmds.h
+++ b/smartmontools/atacmds.h
@@ -605,7 +605,7 @@ STATIC_ASSERT(sizeof(ata_sct_temperature_history_table) == 512);
 // Log Header
 #pragma pack(1)
 struct ataFarmHeader {
-	uint64_t        signature;        // Log Signature = 0x00004641524D4552
+  uint64_t        signature;        // Log Signature = 0x00004641524D4552
 	uint64_t        majorRev;         // Log Major Revision
 	uint64_t        minorRev;         // Log Rinor Revision
 	uint64_t        pagesSupported;   // Number of Pages Supported
@@ -701,10 +701,10 @@ struct ataFarmErrorStatistics {
 	uint64_t        copyNumber;                                 // Copy Number
 	uint64_t        totalUnrecoverableReadErrors;               // Number of Unrecoverable Read Errors
 	uint64_t        totalUnrecoverableWriteErrors;              // Number of Unrecoverable Write Errors
-	uint64_t        totalReallocations;                         // Number of Re-allocated Sectors
+	uint64_t        totalReallocations;                         // Number of Re-Allocated Sectors
 	uint64_t        totalReadRecoveryAttepts;                   // Number of Read Recovery Attempts
 	uint64_t        totalMechanicalStartRetries;                // Number of Mechanical Start Retries
-	uint64_t        totalReallocationCanidates;                 // Number of Re-allocation Candidate Sectors
+	uint64_t        totalReallocationCanidates;                 // Number of Re-Allocated Candidate Sectors
 	uint64_t        totalASREvents;                             // Number of ASR Events
 	uint64_t        totalCRCErrors;                             // Number of Interface CRC Errors
 	uint64_t        attrSpinRetryCount;                         // Spin Retry Count (Most recent value from array at byte 401 of attribute sector)
@@ -755,7 +755,7 @@ struct ataFarmEnvironmentStatistics {
 	uint64_t         humidity;            // Current Relative Humidity (in units of 0.1%)
 	uint64_t         reserved1;           // Reserved
 	uint64_t         currentMotorPower;   // Current Motor Power, value from most recent SMART Summary Frame
-  uint64_t         current12v;          // Current 12V input (added 3.7)
+  uint64_t         current12v;          // Current 12V input in mV (added 3.7)
   uint64_t         min12v;              // Minimum 12V input from last 3 SMART Summary Frames in mV (added 3.7)
   uint64_t         max12v;              // Maximum 12V input from last 3 SMART Summary Frames in mV (added 3.7)
   uint64_t         current5v;           // Current 5V input in mV (added 3.7)
@@ -844,7 +844,7 @@ STATIC_ASSERT(sizeof(ataFarmReliabilityStatistics) == 8880);
 
 // Seagate Field Access Reliability Metrics log (FARM) all pages
 #pragma pack(1)
-struct ataFarmLogFrame {
+struct ataFarmLog {
   ataFarmHeader                       headerPage;             // Log Header page
 	ataFarmDriveInformation             driveInformationPage;   // Drive Information page
 	ataFarmWorkloadStatistics           workloadPage;           // Workload Statistics page
@@ -853,7 +853,7 @@ struct ataFarmLogFrame {
 	ataFarmReliabilityStatistics        reliabilityPage;        // Reliability Statistics page
 } ATTR_PACKED;
 #pragma pack()
-STATIC_ASSERT(sizeof(ataFarmLogFrame) == 72 + 376 + 168 + 952 + 256 + 8880);
+STATIC_ASSERT(sizeof(ataFarmLog) == 72 + 376 + 168 + 952 + 256 + 8880);
 
 // Possible values for span_args.mode
 enum {

--- a/smartmontools/ataprint.cpp
+++ b/smartmontools/ataprint.cpp
@@ -3440,7 +3440,7 @@ static void print_standby_timer(const char * msg, int timer, const ata_identify_
  */
 static bool isSeagate(ata_identify_device * drive) {
   // FIX ME: Seagate model numbers mostly begin with "ST" (all FARM-supported ones do)
-  // FIX ME: Add matching for "XS", as some Seagate drives are labeled that way
+  // FIX ME: Add matching for "XS", as some Seagate drives are labeled like that
   #define SEAGATE_MODEL_MATCH "ST"
   char model[40+1];
   ata_format_id_string(model, drive->model, sizeof(model)-1);

--- a/smartmontools/ataprint.cpp
+++ b/smartmontools/ataprint.cpp
@@ -2240,6 +2240,12 @@ static bool ataPrintFarmLog(ataFarmLog * ptr_farmLog) {
   jout("Number of IOEDC Errors: %lu\n", ptr_farmLog->errorPage.attrIOEDCErrors);
   jout("Error Rate (Normalized): %li\n", ptr_farmLog->reliabilityPage.attrErrorRateNormal);
   jout("Seek Error Rate (Normalized): %li\n", ptr_farmLog->reliabilityPage.attrSeekErrorRateNormal);
+  jout("Current 12V Input (mV): %lu\n", ptr_farmLog->environmentPage.current12v);
+  jout("Minimum 12V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environmentPage.min12v);
+  jout("Maximum 12V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environmentPage.max12v);
+  jout("Current 5V Input (mV): %lu\n", ptr_farmLog->environmentPage.current5v);
+  jout("Minimum 5V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environmentPage.min5v);
+  jout("Maximum 5V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environmentPage.max5v);
   // Print JSON if --json or -j is specified
   json::ref jref = jglb["seagate_farm_log"];
   jref["log_major_revision"] = ptr_farmLog->headerPage.majorRev;
@@ -2252,6 +2258,12 @@ static bool ataPrintFarmLog(ataFarmLog * ptr_farmLog) {
   jref["number_of_ioedc_errors"] = ptr_farmLog->errorPage.attrIOEDCErrors;
   jref["error_rate_normalized"] = ptr_farmLog->reliabilityPage.attrErrorRateNormal;
   jref["seek_error_rate_normalized"] = ptr_farmLog->reliabilityPage.attrSeekErrorRateNormal;
+  jref["current_12_volt_input_in_mv"] = ptr_farmLog->environmentPage.current12v;
+  jref["minimum_12_volt_input_in_mv"] = ptr_farmLog->environmentPage.min12v;
+  jref["maximum_12_volt_input_in_mv"] = ptr_farmLog->environmentPage.max12v;
+  jref["current_5_volt_input_in_mv"] = ptr_farmLog->environmentPage.current5v;
+  jref["minimum_5_volt_input_in_mv"] = ptr_farmLog->environmentPage.min5v;
+  jref["maximum_5_volt_input_in_mv"] = ptr_farmLog->environmentPage.max5v;
   return true;
 }
 

--- a/smartmontools/ataprint.cpp
+++ b/smartmontools/ataprint.cpp
@@ -2230,40 +2230,22 @@ static bool printFarmLog(ataFarmLogFrame * ptr_farmLog) {
   }
   // Print plain-text
   jout("Seagate Field Access Reliability Metrics log (FARM) (GP log 0xA6)\n");
-  jout("Number of Unrecoverable Read Errors: %lu\n", ptr_farmLog->errorPage.totalReadECC);
-  jout("Number of Unrecoverable Write Errors: %lu\n",ptr_farmLog->errorPage.totalWriteECC);
+  jout("Number of Unrecoverable Read Errors: %lu\n", ptr_farmLog->errorPage.totalUnrecoverableReadErrors);
+  jout("Number of Unrecoverable Write Errors: %lu\n",ptr_farmLog->errorPage.totalUnrecoverableWriteErrors);
   jout("Number of Reallocated Sectors: %lu\n", ptr_farmLog->errorPage.totalReallocations);
   jout("Number of Read Recovery Attempts: %lu\n", ptr_farmLog->errorPage.totalReadRecoveryAttepts);
-  jout("Number of Mechanical Start Failures: %lu\n", ptr_farmLog->errorPage.totalMechanicalFails);
+  jout("Number of Mechanical Start Failures: %lu\n", ptr_farmLog->errorPage.totalMechanicalStartRetries);
   jout("Number of IOEDC Errors: %lu\n", ptr_farmLog->errorPage.attrIOEDCErrors);
-  jout("Disc Slip in Micro-Inches by Head:\n");
-  for (unsigned i = 0; i < ptr_farmLog->driveInformationPage.heads; i++) {
-    jout("\tHead %u: %lu\n", i, ptr_farmLog->reliabilityPage.discSlip[i]);
-  }
-  jout("Bit Error Rate by Head:\n");
-  for (unsigned i = 0; i < ptr_farmLog->driveInformationPage.heads; i++) {
-    jout("\tHead %u: %lu\n", i, ptr_farmLog->reliabilityPage.discSlip[i]);
-  }
   jout("Error Rate (Normalized): %li\n", ptr_farmLog->reliabilityPage.attrErrorRateNormal);
   jout("Seek Error Rate (Normalized): %li\n", ptr_farmLog->reliabilityPage.attrSeekErrorRateNormal);
   // Print JSON if --json or -j is specified
   json::ref jref = jglb["seagate_farm_log"];
-  jref["number_of_unrecoverable_read_errors"] = ptr_farmLog->errorPage.totalReadECC;
-  jref["number_of_unrecoverable_write_errors"] = ptr_farmLog->errorPage.totalWriteECC;
+  jref["number_of_unrecoverable_read_errors"] = ptr_farmLog->errorPage.totalUnrecoverableReadErrors;
+  jref["number_of_unrecoverable_write_errors"] = ptr_farmLog->errorPage.totalUnrecoverableWriteErrors;
   jref["number_of_reallocated_sectors"] = ptr_farmLog->errorPage.totalReallocations;
   jref["number_of_read_recovery_attempts"] = ptr_farmLog->errorPage.totalReadRecoveryAttepts;
-  jref["number_of_mechanical_start_failures"] = ptr_farmLog->errorPage.totalMechanicalFails;
+  jref["number_of_mechanical_start_failures"] = ptr_farmLog->errorPage.totalMechanicalStartRetries;
   jref["number_of_ioedc_errors"] = ptr_farmLog->errorPage.attrIOEDCErrors;
-  for (unsigned i = 0; i < ptr_farmLog->driveInformationPage.heads; i++) {
-    char buffer[10];
-    sprintf(buffer, "head_%u", i);
-    jref["disc_slip_in_micro_inches_by_head"][buffer] = ptr_farmLog->reliabilityPage.discSlip[i];
-  }
-  for (unsigned i = 0; i < ptr_farmLog->driveInformationPage.heads; i++) {
-    char buffer[10];
-    sprintf(buffer, "head_%u", i);
-    jref["bit_error_rate_by_head"][buffer] = ptr_farmLog->reliabilityPage.bitErrorRate[i];
-  }
   jref["error_rate_normalized"] = ptr_farmLog->reliabilityPage.attrErrorRateNormal;
   jref["seek_error_rate_normalized"] = ptr_farmLog->reliabilityPage.attrSeekErrorRateNormal;
   return true;

--- a/smartmontools/ataprint.cpp
+++ b/smartmontools/ataprint.cpp
@@ -2230,6 +2230,8 @@ static bool ataPrintFarmLog(ataFarmLog * ptr_farmLog) {
   }
   // Print plain-text
   jout("\nSeagate Field Access Reliability Metrics log (FARM) (GP log 0xA6)\n");
+  jout("FARM Log Major Revision: %lu\n", ptr_farmLog->headerPage.majorRev);
+  jout("FARM Log Minor Revision: %lu\n", ptr_farmLog->headerPage.minorRev);
   jout("Number of Unrecoverable Read Errors: %lu\n", ptr_farmLog->errorPage.totalUnrecoverableReadErrors);
   jout("Number of Unrecoverable Write Errors: %lu\n",ptr_farmLog->errorPage.totalUnrecoverableWriteErrors);
   jout("Number of Reallocated Sectors: %lu\n", ptr_farmLog->errorPage.totalReallocations);
@@ -2240,6 +2242,8 @@ static bool ataPrintFarmLog(ataFarmLog * ptr_farmLog) {
   jout("Seek Error Rate (Normalized): %li\n", ptr_farmLog->reliabilityPage.attrSeekErrorRateNormal);
   // Print JSON if --json or -j is specified
   json::ref jref = jglb["seagate_farm_log"];
+  jref["log_major_revision"] = ptr_farmLog->headerPage.majorRev;
+  jref["log_minor_revision"] = ptr_farmLog->headerPage.minorRev;
   jref["number_of_unrecoverable_read_errors"] = ptr_farmLog->errorPage.totalUnrecoverableReadErrors;
   jref["number_of_unrecoverable_write_errors"] = ptr_farmLog->errorPage.totalUnrecoverableWriteErrors;
   jref["number_of_reallocated_sectors"] = ptr_farmLog->errorPage.totalReallocations;

--- a/smartmontools/ataprint.cpp
+++ b/smartmontools/ataprint.cpp
@@ -3440,7 +3440,7 @@ static void print_standby_timer(const char * msg, int timer, const ata_identify_
  */
 static bool isSeagate(ata_identify_device * drive) {
   // FIX ME: Seagate model numbers mostly begin with "ST" (all FARM-supported ones do)
-  // FIX ME: Add matching for "XS", as some Seagate drives are labeled like that
+  // FIX ME: Add matching for "XS", as some Seagate drives are labeled in this way
   #define SEAGATE_MODEL_MATCH "ST"
   char model[40+1];
   ata_format_id_string(model, drive->model, sizeof(model)-1);

--- a/smartmontools/ataprint.cpp
+++ b/smartmontools/ataprint.cpp
@@ -2229,7 +2229,7 @@ static bool ataPrintFarmLog(ataFarmLog * ptr_farmLog) {
     return false;
   }
   // Print plain-text
-  jout("Seagate Field Access Reliability Metrics log (FARM) (GP log 0xA6)\n");
+  jout("\nSeagate Field Access Reliability Metrics log (FARM) (GP log 0xA6)\n");
   jout("Number of Unrecoverable Read Errors: %lu\n", ptr_farmLog->errorPage.totalUnrecoverableReadErrors);
   jout("Number of Unrecoverable Write Errors: %lu\n",ptr_farmLog->errorPage.totalUnrecoverableWriteErrors);
   jout("Number of Reallocated Sectors: %lu\n", ptr_farmLog->errorPage.totalReallocations);

--- a/smartmontools/ataprint.cpp
+++ b/smartmontools/ataprint.cpp
@@ -3512,6 +3512,7 @@ int ataPrintMain (ata_device * device, const ata_print_options & options)
        || options.devstat_ssd_page
        || !options.devstat_pages.empty()
        || options.pending_defects_log
+       || options.farm_log
   );
 
   unsigned i;
@@ -4548,8 +4549,7 @@ int ataPrintMain (ata_device * device, const ata_print_options & options)
   // Print ATA FARM log for Seagate ATA drive
   if (options.farm_log) {
     if (isSeagate(&drive)) {
-      unsigned nsectors = GetNumLogSectors(gplogdir, 0xA6, true);
-      if (!nsectors) {
+      if (!GetNumLogSectors(gplogdir, 0xA6, true)) {
         pout("FARM log (GP Log 0xA6) not supported\n\n");
       } else {
         ataFarmLogFrame * ptr_farmLog = readFarmLog(device);
@@ -4559,10 +4559,11 @@ int ataPrintMain (ata_device * device, const ata_print_options & options)
         } else {
           if (!printFarmLog(ptr_farmLog)) {
             pout("Print FARM log (GP Log 0xA6) failed\n\n");
+          } else {
+            pout("Read and print FARM log (GP Log 0xA6) for supported Seagate ATA drive succeeded\n\n");
           }
         }
       }
-      pout("Read and print FARM log (GP Log 0xA6) for supported Seagate ATA drive succeeded\n\n");
     } else {
       pout("FARM log (GP Log 0xA6) not supported for non-Seagate drives\n\n");
     }

--- a/smartmontools/ataprint.h
+++ b/smartmontools/ataprint.h
@@ -42,6 +42,8 @@ struct ata_print_options
   bool smart_selftest_log;
   bool smart_selective_selftest_log;
 
+  bool farm_log; // Seagate Field Access Reliability Metrics log (FARM) for ATA
+
   bool gp_logdir, smart_logdir;
   unsigned smart_ext_error_log;
   unsigned smart_ext_selftest_log;
@@ -115,6 +117,7 @@ struct ata_print_options
       smart_error_log(false),
       smart_selftest_log(false),
       smart_selective_selftest_log(false),
+      farm_log(false),
       gp_logdir(false), smart_logdir(false),
       smart_ext_error_log(0),
       smart_ext_selftest_log(0),

--- a/smartmontools/scsicmds.h
+++ b/smartmontools/scsicmds.h
@@ -231,7 +231,11 @@ struct scsi_readcap_resp {
 
 /* Seagate vendor specific log pages. */
 #define SEAGATE_CACHE_LPAGE                 0x37
+#define SEAGATE_FARM_LPAGE                  0x3d
 #define SEAGATE_FACTORY_LPAGE               0x3e
+
+/* Seagate vendor specific log sub-pages. */
+#define SEAGATE_FARM_CURRENT_L_SPAGE        0x3     /* 0x3d,0x3 */
 
 /* Log page response lengths */
 #define LOG_RESP_SELF_TEST_LEN 0x194

--- a/smartmontools/scsicmds.h
+++ b/smartmontools/scsicmds.h
@@ -25,6 +25,9 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include "static_assert.h"
+
+#define ATTR_PACKED __attribute__((packed))
 
 /* #define SCSI_DEBUG 1 */ /* Comment out to disable command debugging */
 
@@ -166,6 +169,392 @@ struct scsi_readcap_resp {
     bool lbprz;         /* Logical Block Provisioning Read Zeros */
     uint16_t l_a_lba;   /* Lowest Aligned Logical Block Address */
 };
+
+// Seagate Field Access Reliability Metrics log (FARM) PAGE Header (read with SCSI LogSense page 0x3D, sub-page 0x3)
+// Page Header
+#pragma pack(1)
+struct scsiFarmPageHeader {
+    uint8_t             pageCode;       // Page Code (0x3D)
+	uint8_t             subpageCode;    // Sub-Page Code (0x03)
+	uint16_t            pageLength;     // Page Length
+} ATTR_PACKED;
+#pragma pack()
+STATIC_ASSERT(sizeof(scsiFarmPageHeader) == 4);
+
+// Seagate Field Access Reliability Metrics log (FARM) PARAMETER Header (read with SCSI LogSense page 0x3D, sub-page 0x3)
+// Parameter Header
+#pragma pack(1)
+struct scsiFarmParameterHeader {
+    uint16_t            parameterCode;       // Page Code (0x3D)
+	uint8_t             parameterControl;    // Sub-Page Code (0x03)
+	uint8_t             parameterLength;     // Page Length
+} ATTR_PACKED;
+#pragma pack()
+STATIC_ASSERT(sizeof(scsiFarmParameterHeader) == 4);
+
+// Seagate Field Access Reliability Metrics log (FARM) parameter (read with SCSI LogSense page 0x3D, sub-page 0x3)
+// Log Header
+#pragma pack(1)
+struct scsiFarmHeader {
+    scsiFarmParameterHeader parameterHeader;        // Parameter Header
+    uint64_t                signature;              // Log Signature = 0x00004641524D4552
+    uint64_t                majorRev;               // Log Major Revision
+    uint64_t                minorRev;               // Log Rinor Revision
+    uint64_t                parametersSupported;    // Number of Parameters Supported
+    uint64_t                logSize;                // Log Page Size in Bytes
+    uint64_t                reserved;               // Reserved
+    uint64_t                headsSupported;         // Maximum Drive Heads Supported
+    uint64_t                reserved0;              // Reserved
+    uint64_t                frameCapture;           // Reason for Frame Capture
+} ATTR_PACKED;
+#pragma pack()
+STATIC_ASSERT(sizeof(scsiFarmHeader) == 76);
+
+// Seagate Field Access Reliability Metrics log (FARM) parameter (read with SCSI LogSense page 0x3D, sub-page 0x3)
+// Drive Information
+#pragma pack(1)
+struct scsiFarmDriveInformation {
+    scsiFarmParameterHeader parameterHeader;    // Parameter Header
+    uint64_t        pageNumber;                 // Page Number = 1
+    uint64_t        copyNumber;                 // Copy Number
+    uint64_t        serialNumber;               // Serial Number [0:3]
+    uint64_t        serialNumber2;              // Serial Number [4:7]
+    uint64_t        worldWideName;              // World Wide Name [0:3]
+    uint64_t        worldWideName2;             // World Wide Name [4:7]
+    uint64_t        deviceInterface;            // Device Interface
+    uint64_t        deviceCapacity;             // 48-bit Device Capacity
+    uint64_t        psecSize;                   // Physical Sector Size in Bytes
+    uint64_t        lsecSize;                   // Logical Sector Size in Bytes
+    uint64_t        deviceBufferSize;           // Device Buffer Size in Bytes
+    uint64_t        heads;                      // Number of Heads
+    uint64_t        factor;                     // Device Form Factor (ID Word 168)
+    uint64_t        rotationRate;               // Rotational Rate of Device (ID Word 217)
+    uint64_t        firmwareRev;                // Firmware Revision [0:3]
+    uint64_t        firmwareRev2;               // Firmware Revision [4:7]
+    uint64_t        reserved;                   // Reserved
+    uint64_t        reserved0;                  // Reserved
+    uint64_t        reserved1;                  // Reserved
+    uint64_t        poh;                        // Power-On Hours
+    uint64_t        reserved2;                  // Reserved
+    uint64_t        reserved3;                  // Reserved
+    uint64_t        reserved4;                  // Reserved
+    uint64_t        powerCycleCount;            // Power Cycle Count
+    uint64_t        resetCount;                 // Hardware Reset Count
+    uint64_t        reserved5;                  // Reserved
+    uint64_t        reserved6;                  // Reserved
+    uint64_t        reserved7;                  // Reserved
+    uint64_t        reserved8;                  // Reserved
+    uint64_t        reserved9;                  // Reserved
+    uint64_t        dateOfAssembly;             // Date of assembly in ASCII “YYWW” where YY is the year and WW is the calendar week (added 4.2)
+} ATTR_PACKED;
+#pragma pack()
+STATIC_ASSERT(sizeof(scsiFarmDriveInformation) == 252);
+
+// Seagate Field Access Reliability Metrics log (FARM) parameter (read with SCSI LogSense page 0x3D, sub-page 0x3)
+// Workload Statistics
+#pragma pack(1)
+struct scsiFarmWorkloadStatistics {
+    scsiFarmParameterHeader parameterHeader;  // Parameter Header
+	uint64_t        pageNumber;               // Page Number = 2
+	uint64_t        copyNumber;               // Copy Number
+	uint64_t        reserved;                 // Reserved
+	uint64_t        totalReadCommands;        // Total Number of Read Commands
+	uint64_t        totalWriteCommands;       // Total Number of Write Commands
+	uint64_t        totalRandomReads;         // Total Number of Random Read Commands
+	uint64_t        totalRandomWrites;        // Total Number of Random Write Commands
+	uint64_t        totalNumberofOtherCMDS;   // Total Number Of Other Commands
+	uint64_t        logicalSecWritten;        // Logical Sectors Written
+	uint64_t        logicalSecRead;           // Logical Sectors Read
+    uint64_t        readCommandsByRadius1;    // Number of Read Commands from 0-3.125% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    uint64_t        readCommandsByRadius2;    // Number of Read Commands from 3.125-25% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    uint64_t        readCommandsByRadius3;    // Number of Read Commands from 25-75% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    uint64_t        readCommandsByRadius4;    // Number of Read Commands from 75-100% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    uint64_t        writeCommandsByRadius1;   // Number of Write Commands from 0-3.125% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    uint64_t        writeCommandsByRadius2;   // Number of Write Commands from 3.125-25% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    uint64_t        writeCommandsByRadius3;   // Number of Write Commands from 25-75% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    uint64_t        writeCommandsByRadius4;   // Number of Write Commands from 75-100% of LBA space for last 3 SMART Summary Frames (added 4.4)
+} ATTR_PACKED;
+#pragma pack()
+STATIC_ASSERT(sizeof(scsiFarmWorkloadStatistics) == 148);
+
+// Seagate Field Access Reliability Metrics log (FARM) parameter (read with SCSI LogSense page 0x3D, sub-page 0x3)
+// Error Statistics
+#pragma pack(1)
+struct scsiFarmErrorStatistics {
+    scsiFarmParameterHeader parameterHeader;        // Parameter Header
+	uint64_t        pageNumber;                     // Page Number = 3
+	uint64_t        copyNumber;                     // Copy Number
+	uint64_t        totalUnrecoverableReadErrors;   // Number of Unrecoverable Read Errors
+	uint64_t        totalUnrecoverableWriteErrors;  // Number of Unrecoverable Write Errors
+	uint64_t        reserved;                       // Reserved
+	uint64_t        reserved0;                      // Reserved
+	uint64_t        totalMechanicalStartRetries;    // Number of Mechanical Start Retries
+	uint64_t        reserved1;                      // Reserved
+	uint64_t        reserved2;                      // Reserved
+	uint64_t        reserved3;                      // Reserved
+	uint64_t        reserved4;                      // Reserved
+	uint64_t        reserved5;                      // Reserved
+	uint64_t        reserved6;                      // Reserved
+	uint64_t        reserved7;                      // Reserved
+	uint64_t        reserved8;                      // Reserved
+	uint64_t        reserved9;                      // Reserved
+	uint64_t        reserved10;                     // Reserved
+	uint64_t        reserved11;                     // Reserved
+	uint64_t        reserved12;                     // Reserved
+	uint64_t        reserved13;                     // Reserved
+    uint64_t        tripCode;                       // If SMART Trip present the reason code (FRU code)
+    uint64_t        invalidDWordCountA;             // Invalid DWord Count (Port A)
+    uint64_t        invalidDWordCountB;             // Invalid DWord Count (Port B)                    
+    uint64_t        disparityErrorCodeA;            // Disparity Error Count (Port A)        
+    uint64_t        disparityErrorCodeB;            // Disparity Error Count (Port A)        
+    uint64_t        lossOfDWordSyncA;               // Loss of DWord Sync (Port A)    
+    uint64_t        lossOfDWordSyncB;               // Loss of DWord Sync (Port A)    
+    uint64_t        phyResetProblemA;               // Phy Reset Problem (Port A)    
+    uint64_t        phyResetProblemB;               // Phy Reset Problem (Port A)    
+} ATTR_PACKED;
+#pragma pack()
+STATIC_ASSERT(sizeof(scsiFarmErrorStatistics) == 236);
+
+// Seagate Field Access Reliability Metrics log (FARM) parameter (read with SCSI LogSense page 0x3D, sub-page 0x3)
+// Environment Statistics
+#pragma pack(1)
+struct scsiFarmEnvironmentStatistics {
+    scsiFarmParameterHeader parameterHeader;    // Parameter Header
+	uint64_t         pageNumber;                // Page Number = 4
+	uint64_t         copyNumber;                // Copy Number
+	uint64_t         curentTemp;                // Current Temperature in Celsius (Lower 16 bits are a signed integer in units of 0.1C)
+	uint64_t         highestTemp;               // Highest Temperature in Celsius (Lower 16 bits are a signed integer in units of 0.1C)
+	uint64_t         lowestTemp;                // Lowest Temperature in Celsius (Lower 16 bits are a signed integer in units of 0.1C)  
+	uint64_t         reserved;                  // Reserved
+	uint64_t         reserved0;                 // Reserved
+	uint64_t         reserved1;                 // Reserved
+	uint64_t         reserved2;                 // Reserved
+	uint64_t         reserved3;                 // Reserved
+	uint64_t         reserved4;                 // Reserved
+	uint64_t         reserved5;                 // Reserved
+	uint64_t         reserved6;                 // Reserved
+	uint64_t         maxTemp;                   // Specified Max Operating Temperature in Celsius
+	uint64_t         minTemp;                   // Specified Min Operating Temperature in Celsius
+	uint64_t         reserved7;                 // Reserved
+	uint64_t         reserved8;                 // Reserved
+	uint64_t         humidity;                  // Current Relative Humidity (in units of 0.1%)
+	uint64_t         reserved9;                 // Reserved
+	uint64_t         currentMotorPower;         // Current Motor Power, value from most recent SMART Summary Frame
+    uint64_t         powerAverage12v;           // 12V Power Average (mW) - Average of last 3 SMART Summary Frames (added 4.3)
+    uint64_t         powerMin12v;               // 12V Power Min (mW) - Lowest of last 3 SMART Summary Frames (added 4.3)
+    uint64_t         powerMax12v;               // 12V Power Max (mW) - Highest of last 3 SMART Summary Frames (added 4.3)
+    uint64_t         powerAverage5v;            // 5V Power Average (mW) - Average of last 3 SMART Summary Frames (added 4.3)
+    uint64_t         powerMin5v;                // 5V Power Min (mW) - Lowest of last 3 SMART Summary Frames (added 4.3)
+    uint64_t         powerMax5v;                // 5V Power Max (mW) - Highest of last 3 SMART Summary Frames (added 4.3)
+} ATTR_PACKED;
+#pragma pack()
+STATIC_ASSERT(sizeof(scsiFarmEnvironmentStatistics) == 212);
+
+// Seagate Field Access Reliability Metrics log (FARM) parameter (read with SCSI LogSense page 0x3D, sub-page 0x3)
+// Reliability Statistics
+#pragma pack(1)
+struct scsiFarmReliabilityStatistics {
+    scsiFarmParameterHeader parameterHeader;            // Parameter Header
+	int64_t         pageNumber;                         // Page Number = 5
+	int64_t         copyNumber;                         // Copy Number
+	uint64_t        reserved;                           // Reserved
+	uint64_t        reserved0;                          // Reserved
+	uint64_t        reserved1;                          // Reserved
+	uint64_t        reserved2;                          // Reserved
+	uint64_t        reserved3;                          // Reserved
+	uint64_t        reserved4;                          // Reserved
+	uint64_t        reserved5;                          // Reserved
+	uint64_t        reserved6;                          // Reserved
+	uint64_t        reserved7;                          // Reserved
+	uint64_t        reserved8;                          // Reserved
+	uint64_t        reserved9;                          // Reserved
+	uint64_t        reserved10;                         // Reserved
+	uint64_t        reserved11;                         // Reserved
+	uint64_t        reserved12;                         // Reserved
+	uint64_t        reserved13;                         // Reserved
+	uint64_t        reserved14;                         // Reserved
+    uint64_t        reserved15;                         // Reserved
+	uint64_t        reserved16;                         // Reserved
+	uint64_t        reserved17;                         // Reserved
+	uint64_t        reserved18;                         // Reserved
+	uint64_t        reserved19;                         // Reserved
+    uint64_t        reserved20;                         // Reserved
+    uint64_t        reserved21;                         // Reserved
+	int64_t         heliumPresureTrip;                  // Helium Pressure Threshold Tripped ( 1 - trip, 0 - no trip)
+	uint64_t        reserved34;                         // Reserved
+	uint64_t        reserved35;                         // Reserved
+	uint64_t        reserved36;                         // Reserved
+} ATTR_PACKED;
+#pragma pack()
+STATIC_ASSERT(sizeof(scsiFarmReliabilityStatistics) == 236);
+
+// Seagate Field Access Reliability Metrics log (FARM) parameter (read with SCSI LogSense page 0x3D, sub-page 0x3)
+// Drive Information Continued
+#pragma pack(1)
+struct scsiFarmDriveInformation2 {
+    scsiFarmParameterHeader parameterHeader;    // Parameter Header
+    uint64_t        pageNumber;                 // Page Number = 6
+    uint64_t        copyNumber;                 // Copy Number
+    uint64_t        depopulationHeadMask;       // Depopulation Head Mask
+    uint64_t        productID;                  // Product ID [0:3]
+    uint64_t        productID2;                 // Product ID [4:7]
+    uint64_t        productID3;                 // Product ID [8:11]
+    uint64_t        productID4;                 // Product ID [12:15]
+    uint64_t        driveRecordingType;         // Drive Recording Type - 0 for SMR and 1 for CMR
+    uint64_t        dpopped;                    // Is drive currently depopped – 1 = depopped, 0 = not depopped 
+    uint64_t        maxNumberForReasign;        // Max Number of Available Sectors for Re-Assignment – Value in disc sectors 
+    uint64_t        timeToReady;                // Time to Ready of the last power cycle in milliseconds  
+    uint64_t        timeHeld;                   // Time the drive is held in staggered spin in milliseconds 
+    uint64_t        lastServoSpinUpTime;        // The last servo spin up time in milliseconds 
+} ATTR_PACKED;
+#pragma pack()
+STATIC_ASSERT(sizeof(scsiFarmDriveInformation2) == 108);
+
+// Seagate Field Access Reliability Metrics log (FARM) parameter (read with SCSI LogSense page 0x3D, sub-page 0x3)
+// Environment Statistics Continued
+#pragma pack(1)
+struct scsiFarmEnvironmentStatistics2 {
+    scsiFarmParameterHeader parameterHeader;    // Parameter Header
+	uint64_t         pageNumber;                // Page Number = 7
+	uint64_t         copyNumber;                // Copy Number
+	uint64_t         current12v;                // Current 12V input in mV
+    uint64_t         min12v;                    // Minimum 12V input from last 3 SMART Summary Frames in mV
+    uint64_t         max12v;                    // Maximum 12V input from last 3 SMART Summary Frames in mV
+    uint64_t         current5v;                 // Current 5V input in mV
+    uint64_t         min5v;                     // Minimum 5V input from last 3 SMART Summary Frames in mV
+    uint64_t         max5v;                     // Maximum 5V input from last 3 SMART Summary Frames in mV
+} ATTR_PACKED;
+#pragma pack()
+STATIC_ASSERT(sizeof(scsiFarmEnvironmentStatistics2) == 68);
+
+// Seagate Field Access Reliability Metrics log (FARM) parameter (read with SCSI LogSense page 0x3D, sub-page 0x3)
+// "By Head" Parameters
+#pragma pack(1)
+struct scsiFarmByHead {
+    scsiFarmParameterHeader parameterHeader;    // Parameter Header
+	uint64_t                headValue[16];      // [16] Head Information
+} ATTR_PACKED;
+#pragma pack()
+STATIC_ASSERT(sizeof(scsiFarmByHead) == (4 + (16 * 8)));
+
+// Seagate Field Access Reliability Metrics log (FARM) parameter (read with SCSI LogSense page 0x3D, sub-page 0x3)
+// "By Actuator" Parameters
+#pragma pack(1)
+struct scsiFarmByActuator {
+    scsiFarmParameterHeader parameterHeader;                        // Parameter Header
+	uint64_t                pageNumber;                             // Page Number
+	uint64_t                copyNumber;                             // Copy Number  
+    uint64_t                actuatorID;                             // Actuator ID 
+    uint64_t                headLoadEvents;                         // Head Load Events 
+    uint64_t                reserved;                               // Reserved 
+    uint64_t                reserved0;                              // Reserved 
+    uint64_t                timelastIDDTest;                        // Timestamp of last IDD test 
+    uint64_t                subcommandlastIDDTest;                  // Sub-Command of last IDD test 
+    uint64_t                numberGListReclam;                      // Number of G-list reclamations 
+    uint64_t                servoStatus;                            // Servo Status (follows standard DST error code definitions) 
+    uint64_t                numberSlippedSectorsBeforeIDD;          // Number of Slipped Sectors Before IDD Scan 
+    uint64_t                numberSlippedSectorsAfterIDD;           // Number of Slipped Sectors After IDD Scan 
+    uint64_t                numberResidentReallocatedBeforeIDD;     // Number of Resident Reallocated Sectors Before IDD Scan 
+    uint64_t                numberResidentReallocatedAfterIDD;      // Number of Resident Reallocated Sectors After IDD Scan 
+    uint64_t                numberScrubbedSectorsBeforeIDD;         // Number of Successfully Scrubbed Sectors Before IDD Scan 
+    uint64_t                numberScrubbedSectorsAfterIDD;          // Number of Successfully Scrubbed Sectors After IDD Scan 
+    uint64_t                dosScansPerformed;                      // Number of DOS Scans Performed 
+    uint64_t                lbasCorrectedISP;                       // Number of LBAs Corrected by ISP 
+    uint64_t                numberValidParitySectors;               // Number of Valid Parity Sectors 
+    uint64_t                reserved1;                              // Reserved 
+    uint64_t                reserved2;                              // Reserved 
+    uint64_t                reserved3;                              // Reserved 
+    uint64_t                numberLBACorrectedParitySector;         // Number of LBAs Corrected by Parity Sector 
+} ATTR_PACKED;
+#pragma pack()
+STATIC_ASSERT(sizeof(scsiFarmByActuator) == (188));
+
+// Seagate Field Access Reliability Metrics log (FARM) parameter (read with SCSI LogSense page 0x3D, sub-page 0x3)
+// "By Actuator" Parameters for Flash LED Information
+#pragma pack(1)
+struct scsiFarmByActuatorFLED {
+    scsiFarmParameterHeader parameterHeader;                        // Parameter Header
+	uint64_t                pageNumber;                             // Page Number
+	uint64_t                copyNumber;                             // Copy Number  
+    uint64_t                actuatorID;                             // Actuator ID 
+    uint64_t                totalFlashLED;                          // Total Flash LED (Assert) Events
+    uint64_t                indexFlashLED;                          // Index of last entry in Flash LED Info array below, in case the array wraps
+    uint64_t                flashLEDArray[8];                       // Info on the last 8 Flash LED (assert) events wrapping array
+    uint64_t                universalTimestampFlashLED[8];          // Universal Timestamp (us) of last 8 Flash LED (assert) Events, wrapping array
+    uint64_t                powerCycleFlashLED[8];                  // Power Cycle of the last 8 Flash LED (assert) Events, wrapping array
+} ATTR_PACKED;
+#pragma pack()
+STATIC_ASSERT(sizeof(scsiFarmByActuatorFLED) == (236));
+
+// Seagate Field Access Reliability Metrics log (FARM) parameter (read with SCSI LogSense page 0x3D, sub-page 0x3)
+// "By Actuator" Parameters for Reallocation Information
+#pragma pack(1)
+struct scsiFarmByActuatorReallocation {
+    scsiFarmParameterHeader parameterHeader;                        // Parameter Header
+	uint64_t                pageNumber;                             // Page Number
+	uint64_t                copyNumber;                             // Copy Number  
+    uint64_t                actuatorID;                             // Actuator ID 
+    uint64_t                totalReallocations;                     // Number of Re-Allocated Sectors
+    uint64_t                totalReallocationCanidates;             // Number of Re-Allocated Candidate Sectors 
+    uint64_t                reserved[15];                           // Reserved
+} ATTR_PACKED;
+#pragma pack()
+STATIC_ASSERT(sizeof(scsiFarmByActuatorReallocation) == (164));
+
+// Seagate Field Access Reliability Metrics log (FARM) all parameters
+#pragma pack(1)
+struct scsiFarmLog {
+    scsiFarmPageHeader                      pageHeader;                             // Head for whole log page
+    scsiFarmHeader                          header;                                 // Log Header parameter
+	scsiFarmDriveInformation                driveInformation;                       // Drive Information parameter
+	scsiFarmWorkloadStatistics              workload;                               // Workload Statistics parameter
+	scsiFarmErrorStatistics                 error;                                  // Error Statistics parameter
+	scsiFarmEnvironmentStatistics           environment;                            // Environment Statistics parameter 
+	scsiFarmReliabilityStatistics           reliability;                            // Reliability Statistics parameter
+    scsiFarmDriveInformation2               driveInformation2;                      // Drive Information parameter continued
+    scsiFarmEnvironmentStatistics2          environment2;                           // Environment Statistics parameter continued
+    scsiFarmByHead                          reserved;                               // Reserved
+    scsiFarmByHead                          reserved0;                              // Reserved
+    scsiFarmByHead                          reserved1;                              // Reserved
+    scsiFarmByHead                          reserved2;                              // Reserved
+    scsiFarmByHead                          reserved3;                              // Reserved
+    scsiFarmByHead                          reserved4;                              // Reserved
+    scsiFarmByHead                          reserved5;                              // Reserved
+    scsiFarmByHead                          reserved6;                              // Reserved
+    scsiFarmByHead                          reserved7;                              // Reserved
+    scsiFarmByHead                          reserved8;                              // Reserved
+    scsiFarmByHead                          mrHeadResistance;                       // MR Head Resistance from most recent SMART Summary Frame by Head
+    scsiFarmByHead                          reserved9;                              // Reserved
+    scsiFarmByHead                          reserved10;                             // Reserved
+    scsiFarmByHead                          reserved11;                             // Reserved
+    scsiFarmByHead                          reserved12;                             // Reserved
+    scsiFarmByHead                          reserved13;                             // Reserved
+    scsiFarmByHead                          reserved14;                             // Reserved
+    scsiFarmByHead                          totalReallocations;                     // Number of Reallocated Sectors
+    scsiFarmByHead                          totalReallocationCanidates;             // Number of Reallocation Candidate Sectors
+    scsiFarmByHead                          reserved15;                             // Reserved
+    scsiFarmByHead                          reserved16;                             // Reserved
+    scsiFarmByHead                          reserved17;                             // Reserved
+    scsiFarmByHead                          writeWorkloadPowerOnTime;               // Write Workload Power-on Time in Seconds, value from most recent SMART Frame by Head
+    scsiFarmByHead                          reserved18;                             // Reserved
+    scsiFarmByHead                          cumulativeUnrecoverableReadRepeat;      // Cumulative Lifetime Unrecoverable Read Repeat by head
+    scsiFarmByHead                          cumulativeUnrecoverableReadUnique;      // Cumulative Lifetime Unrecoverable Read Unique by head
+    scsiFarmByHead                          secondMRHeadResistance;                 // Second Head MR Head Resistance from most recent SMART Summary Frame by Head 
+    scsiFarmByActuator                      actuator0;                              // Actuator 0 parameters
+    scsiFarmByActuatorFLED                  actuatorFLED0;                          // Actuator 0 FLED Information parameters
+    scsiFarmByActuatorReallocation          actuatorReallocation0;                  // Actuator 0 Reallocation parameters
+    scsiFarmByActuator                      actuator1;                              // Actuator 1 parameters
+    scsiFarmByActuatorFLED                  actuatorFLED1;                          // Actuator 1 FLED Information parameters
+    scsiFarmByActuatorReallocation          actuatorReallocation1;                  // Actuator 1 Reallocation parameters
+    scsiFarmByActuator                      actuator2;                              // Actuator 2 parameters
+    scsiFarmByActuatorFLED                  actuatorFLED2;                          // Actuator 2 FLED Information parameters
+    scsiFarmByActuatorReallocation          actuatorReallocation2;                  // Actuator 2 Reallocation parameters
+    scsiFarmByActuator                      actuator3;                              // Actuator 3 parameters
+    scsiFarmByActuatorFLED                  actuatorFLED3;                          // Actuator 3 FLED Information parameters
+    scsiFarmByActuatorReallocation          actuatorReallocation3;                  // Actuator 3 Reallocation parameters
+} ATTR_PACKED;
+#pragma pack()
+STATIC_ASSERT(sizeof(scsiFarmLog) == 4 + 76 + 252 + 148 + 236 + 212 + 236 + 108 + 68 + (27 * ((8 * 16) + 4)) + 188 * 4 + 236 * 4 + 164 * 4);
 
 /* SCSI Peripheral types (of interest) */
 #define SCSI_PT_DIRECT_ACCESS           0x0

--- a/smartmontools/scsicmds.h
+++ b/smartmontools/scsicmds.h
@@ -539,7 +539,27 @@ struct scsiFarmLog {
     scsiFarmByHead                          reserved18;                             // Reserved
     scsiFarmByHead                          cumulativeUnrecoverableReadRepeat;      // Cumulative Lifetime Unrecoverable Read Repeat by head
     scsiFarmByHead                          cumulativeUnrecoverableReadUnique;      // Cumulative Lifetime Unrecoverable Read Unique by head
-    scsiFarmByHead                          secondMRHeadResistance;                 // Second Head MR Head Resistance from most recent SMART Summary Frame by Head 
+    scsiFarmByHead                          reserved19;                             // Reserved
+    scsiFarmByHead                          reserved20;                             // Reserved
+    scsiFarmByHead                          reserved21;                             // Reserved
+    scsiFarmByHead                          reserved22;                             // Reserved
+    scsiFarmByHead                          reserved23;                             // Reserved
+    scsiFarmByHead                          reserved24;                             // Reserved
+    scsiFarmByHead                          reserved25;                             // Reserved
+    scsiFarmByHead                          reserved26;                             // Reserved
+    scsiFarmByHead                          reserved27;                             // Reserved
+    scsiFarmByHead                          secondMRHeadResistance;                 // Second Head MR Head Resistance from most recent SMART Summary Frame by Head
+    scsiFarmByHead                          reserved28;                             // Reserved
+    scsiFarmByHead                          reserved29;                             // Reserved
+    scsiFarmByHead                          reserved30;                             // Reserved
+    scsiFarmByHead                          reserved31;                             // Reserved
+    scsiFarmByHead                          reserved32;                             // Reserved
+    scsiFarmByHead                          reserved33;                             // Reserved
+    scsiFarmByHead                          reserved34;                             // Reserved
+    scsiFarmByHead                          reserved35;                             // Reserved
+    scsiFarmByHead                          reserved36;                             // Reserved
+    scsiFarmByHead                          reserved37;                             // Reserved
+    scsiFarmByHead                          reserved38;                             // Reserved
     scsiFarmByActuator                      actuator0;                              // Actuator 0 parameters
     scsiFarmByActuatorFLED                  actuatorFLED0;                          // Actuator 0 FLED Information parameters
     scsiFarmByActuatorReallocation          actuatorReallocation0;                  // Actuator 0 Reallocation parameters
@@ -554,7 +574,7 @@ struct scsiFarmLog {
     scsiFarmByActuatorReallocation          actuatorReallocation3;                  // Actuator 3 Reallocation parameters
 } ATTR_PACKED;
 #pragma pack()
-STATIC_ASSERT(sizeof(scsiFarmLog) == 4 + 76 + 252 + 148 + 236 + 212 + 236 + 108 + 68 + (27 * ((8 * 16) + 4)) + 188 * 4 + 236 * 4 + 164 * 4);
+STATIC_ASSERT(sizeof(scsiFarmLog) == 4 + 76 + 252 + 148 + 236 + 212 + 236 + 108 + 68 + (47 * ((8 * 16) + 4)) + 188 * 4 + 236 * 4 + 164 * 4);
 
 /* SCSI Peripheral types (of interest) */
 #define SCSI_PT_DIRECT_ACCESS           0x0

--- a/smartmontools/scsiprint.cpp
+++ b/smartmontools/scsiprint.cpp
@@ -1016,6 +1016,8 @@ static bool scsiPrintFarmLog(scsiFarmLog * ptr_farmLog) {
     }
     // Print plain-text
     jout("\nSeagate Field Access Reliability Metrics log (FARM) (SCSI Log page 0x3D, sub-page 0x3)\n");
+    jout("FARM Log Major Revision: %lu\n", ptr_farmLog->header.majorRev);
+    jout("FARM Log Minor Revision: %lu\n", ptr_farmLog->header.minorRev);
     jout("Number of Unrecoverable Read Errors: %lu\n", ptr_farmLog->error.totalUnrecoverableReadErrors);
     jout("Number of Unrecoverable Write Errors: %lu\n",ptr_farmLog->error.totalUnrecoverableWriteErrors);
     //jout("Number of Reallocated Sectors: %lu\n", ptr_farmLog->error.totalReallocations);
@@ -1026,6 +1028,8 @@ static bool scsiPrintFarmLog(scsiFarmLog * ptr_farmLog) {
     //jout("Seek Error Rate (Normalized): %li\n", ptr_farmLog->reliability.attrSeekErrorRateNormal);
     // Print JSON if --json or -j is specified
     json::ref jref = jglb["seagate_farm_log"];
+    jref["log_major_revision"] = ptr_farmLog->header.majorRev;
+    jref["log_minor_revision"] = ptr_farmLog->header.minorRev;
     jref["number_of_unrecoverable_read_errors"] = ptr_farmLog->error.totalUnrecoverableReadErrors;
     jref["number_of_unrecoverable_write_errors"] = ptr_farmLog->error.totalUnrecoverableWriteErrors;
     //jref["number_of_reallocated_sectors"] = ptr_farmLog->errorPage.totalReallocations;

--- a/smartmontools/scsiprint.cpp
+++ b/smartmontools/scsiprint.cpp
@@ -1020,24 +1020,26 @@ static bool scsiPrintFarmLog(scsiFarmLog * ptr_farmLog) {
     jout("FARM Log Minor Revision: %lu\n", ptr_farmLog->header.minorRev);
     jout("Number of Unrecoverable Read Errors: %lu\n", ptr_farmLog->error.totalUnrecoverableReadErrors);
     jout("Number of Unrecoverable Write Errors: %lu\n",ptr_farmLog->error.totalUnrecoverableWriteErrors);
-    //jout("Number of Reallocated Sectors: %lu\n", ptr_farmLog->error.totalReallocations);
-    //jout("Number of Read Recovery Attempts: %lu\n", ptr_farmLog->error.totalReadRecoveryAttepts);
     jout("Number of Mechanical Start Failures: %lu\n", ptr_farmLog->error.totalMechanicalStartRetries);
-    //jout("Number of IOEDC Errors: %lu\n", ptr_farmLog->error.attrIOEDCErrors);
-    //jout("Error Rate (Normalized): %li\n", ptr_farmLog->reliability.attrErrorRateNormal);
-    //jout("Seek Error Rate (Normalized): %li\n", ptr_farmLog->reliability.attrSeekErrorRateNormal);
+    jout("Current 12V Input (mV): %lu\n", ptr_farmLog->environment2.current12v);
+    jout("Minimum 12V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environment2.min12v);
+    jout("Maximum 12V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environment2.max12v);
+    jout("Current 5V Input (mV): %lu\n", ptr_farmLog->environment2.current5v);
+    jout("Minimum 5V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environment2.min5v);
+    jout("Maximum 5V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environment2.max5v);
     // Print JSON if --json or -j is specified
     json::ref jref = jglb["seagate_farm_log"];
     jref["log_major_revision"] = ptr_farmLog->header.majorRev;
     jref["log_minor_revision"] = ptr_farmLog->header.minorRev;
     jref["number_of_unrecoverable_read_errors"] = ptr_farmLog->error.totalUnrecoverableReadErrors;
     jref["number_of_unrecoverable_write_errors"] = ptr_farmLog->error.totalUnrecoverableWriteErrors;
-    //jref["number_of_reallocated_sectors"] = ptr_farmLog->errorPage.totalReallocations;
-    //jref["number_of_read_recovery_attempts"] = ptr_farmLog->errorPage.totalReadRecoveryAttepts;
     jref["number_of_mechanical_start_failures"] = ptr_farmLog->error.totalMechanicalStartRetries;
-    //jref["number_of_ioedc_errors"] = ptr_farmLog->errorPage.attrIOEDCErrors;
-    //jref["error_rate_normalized"] = ptr_farmLog->reliabilityPage.attrErrorRateNormal;
-    //jref["seek_error_rate_normalized"] = ptr_farmLog->reliabilityPage.attrSeekErrorRateNormal;
+    jref["current_12_volt_input_in_mv"] = ptr_farmLog->environment2.current12v;
+    jref["minimum_12_volt_input_in_mv"] = ptr_farmLog->environment2.min12v;
+    jref["maximum_12_volt_input_in_mv"] = ptr_farmLog->environment2.max12v;
+    jref["current_5_volt_input_in_mv"] = ptr_farmLog->environment2.current5v;
+    jref["minimum_5_volt_input_in_mv"] = ptr_farmLog->environment2.min5v;
+    jref["maximum_5_volt_input_in_mv"] = ptr_farmLog->environment2.max5v;
     return true;
 }
 

--- a/smartmontools/scsiprint.cpp
+++ b/smartmontools/scsiprint.cpp
@@ -1019,12 +1019,6 @@ static bool scsiPrintFarmLog(scsiFarmLog * ptr_farmLog) {
     }
     // Print plain-text
     jout("Seagate Field Access Reliability Metrics log (FARM) (SCSI Log page 0x3D, sub-page 0x3)\n");
-    jout("Signature: %lu\n", ptr_farmLog->header.signature);
-    jout("Page Length: %u\n", ptr_farmLog->pageHeader.pageLength);
-    jout("Heads: %lu\n", ptr_farmLog->driveInformation.heads);
-    for (unsigned i = 0; i < 8; i++) {
-        jout("MR Head %u: %lu\n", i, ptr_farmLog->mrHeadResistance.headValue[i]);
-    }
     jout("Number of Unrecoverable Read Errors: %lu\n", ptr_farmLog->error.totalUnrecoverableReadErrors);
     jout("Number of Unrecoverable Write Errors: %lu\n",ptr_farmLog->error.totalUnrecoverableWriteErrors);
     //jout("Number of Reallocated Sectors: %lu\n", ptr_farmLog->error.totalReallocations);

--- a/smartmontools/scsiprint.cpp
+++ b/smartmontools/scsiprint.cpp
@@ -959,10 +959,6 @@ static scsiFarmLog * scsiReadFarmLog(scsi_device * device) {
             if (currentParameterHeader.parameterCode >= 0x83) {
                 currentParameterOffset += sizeof(scsiFarmByActuatorReallocation);
             }
-            pout("PARAMETER CODE: %u\n", currentParameterHeader.parameterCode);
-            pout("PARAMETER LENGTH: %u\n", currentParameterHeader.parameterLength);
-            pout("PAGE OFFSET: %u\n", pageOffset);
-            pout("STRUCT OFFSET: %u\n\n", currentParameterOffset);
             // Copy parameter header to struct
             memcpy((char *) ptr_farmLog + currentParameterOffset, &currentParameterHeader, sizeof(scsiFarmParameterHeader));
             // Fix offset
@@ -1020,12 +1016,6 @@ static bool scsiPrintFarmLog(scsiFarmLog * ptr_farmLog) {
     }
     // Print plain-text
     jout("\nSeagate Field Access Reliability Metrics log (FARM) (SCSI Log page 0x3D, sub-page 0x3)\n");
-    jout("Signature: %lu\n", ptr_farmLog->header.signature);
-    jout("Page Length: %u\n", ptr_farmLog->pageHeader.pageLength);
-    jout("Heads: %lu\n", ptr_farmLog->driveInformation.heads);
-    for (unsigned i = 0; i < 8; i++) {
-        jout("MR Head %u: %lu\n", i, ptr_farmLog->mrHeadResistance.headValue[i]);
-    }
     jout("Number of Unrecoverable Read Errors: %lu\n", ptr_farmLog->error.totalUnrecoverableReadErrors);
     jout("Number of Unrecoverable Write Errors: %lu\n",ptr_farmLog->error.totalUnrecoverableWriteErrors);
     //jout("Number of Reallocated Sectors: %lu\n", ptr_farmLog->error.totalReallocations);

--- a/smartmontools/scsiprint.cpp
+++ b/smartmontools/scsiprint.cpp
@@ -1018,7 +1018,7 @@ static bool scsiPrintFarmLog(scsiFarmLog * ptr_farmLog) {
         return false;
     }
     // Print plain-text
-    jout("Seagate Field Access Reliability Metrics log (FARM) (SCSI Log page 0x3D, sub-page 0x3)\n");
+    jout("\nSeagate Field Access Reliability Metrics log (FARM) (SCSI Log page 0x3D, sub-page 0x3)\n");
     jout("Number of Unrecoverable Read Errors: %lu\n", ptr_farmLog->error.totalUnrecoverableReadErrors);
     jout("Number of Unrecoverable Write Errors: %lu\n",ptr_farmLog->error.totalUnrecoverableWriteErrors);
     //jout("Number of Reallocated Sectors: %lu\n", ptr_farmLog->error.totalReallocations);

--- a/smartmontools/scsiprint.h
+++ b/smartmontools/scsiprint.h
@@ -29,6 +29,8 @@ struct scsi_print_options
   bool smart_background_log;
   bool smart_ss_media_log;
 
+  bool farm_log; // Seagate Field Access Reliability Metrics log (FARM) for SCSI
+
   bool smart_disable, smart_enable;
   bool smart_auto_save_disable, smart_auto_save_enable;
 
@@ -51,6 +53,7 @@ struct scsi_print_options
       smart_selftest_log(false),
       smart_background_log(false),
       smart_ss_media_log(false),
+      farm_log(false),
       smart_disable(false), smart_enable(false),
       smart_auto_save_disable(false), smart_auto_save_enable(false),
       smart_default_selftest(false),

--- a/smartmontools/smartctl.cpp
+++ b/smartmontools/smartctl.cpp
@@ -177,7 +177,7 @@ static void Usage()
 "        xerror[,N][,error], xselftest[,N][,selftest], background,\n"
 "        sasphy[,reset], sataphy[,reset], scttemp[sts,hist],\n"
 "        scttempint,N[,p], scterc[,N,M], devstat[,N], defects[,N], ssd,\n"
-"        gplog,N[,RANGE], smartlog,N[,RANGE], nvmelog,N,SIZE\n\n"
+"        gplog,N[,RANGE], smartlog,N[,RANGE], nvmelog,N,SIZE, farm\n\n"
 "  -v N,OPTION , --vendorattribute=N,OPTION                            (ATA)\n"
 "        Set display OPTION for vendor Attribute N (see man page)\n\n"
 "  -F TYPE, --firmwarebug=TYPE                                         (ATA)\n"
@@ -245,7 +245,7 @@ static std::string getvalidarglist(int opt)
            "scttemp[sts,hist], scttempint,N[,p], "
            "scterc[,N,M], devstat[,N], defects[,N], ssd, "
            "gplog,N[,RANGE], smartlog,N[,RANGE], "
-           "nvmelog,N,SIZE";
+           "nvmelog,N,SIZE, farm";
   case 'P':
     return "use, ignore, show, showall";
   case 't':
@@ -547,7 +547,8 @@ static int parse_options(int argc, char** argv, const char * & type,
         ataopts.sct_temp_sts = true;
       } else if (!strcmp(optarg,"scttemphist")) {
         ataopts.sct_temp_hist = true;
-
+      } else if (!strcmp(optarg,"farm")) {
+        ataopts.farm_log = scsiopts.farm_log = true;
       } else if (!strncmp(optarg, "scttempint,", sizeof("scstempint,")-1)) {
         unsigned interval = 0; int n1 = -1, n2 = -1, len = strlen(optarg);
         if (!(   sscanf(optarg,"scttempint,%u%n,p%n", &interval, &n1, &n2) == 1


### PR DESCRIPTION
Has all the framework for parsing Seagate's vendor specific Field Access Reliability Metrics (FARM) log. Currently parses all FARM log data but only prints out a small subset of FARM parameters. More can be added later. Currently implemented for ATA and SCSI. Can be called with '-l farm' command-line argument.

Parsing of FARM fields occurs in ataprint.cpp and scsiprint.cpp in the ataReadFarmLog() and scsiReadFarmLog() functions. Goes through log binary and parses data into respective FARM log structures as defined in atacmds.h and scsicmds.h

Then, specified FARM fields can be printed using jout in their parsed state(s) in ataPrintFarmLog() and scsiPrintFarmLog() in ataprint.cpp and scsiprint.cpp, respectively. Currently prints around 10 metrics, but more can be added in the future.