### PR TITLE
Added printing of ~20 top metrics for FARM log

### DIFF
--- a/smartmontools/atacmds.h
+++ b/smartmontools/atacmds.h
@@ -605,15 +605,15 @@ STATIC_ASSERT(sizeof(ata_sct_temperature_history_table) == 512);
 // Log Header
 #pragma pack(1)
 struct ataFarmHeader {
-  uint64_t        signature;        // Log Signature = 0x00004641524D4552
-	uint64_t        majorRev;         // Log Major Revision
-	uint64_t        minorRev;         // Log Rinor Revision
-	uint64_t        pagesSupported;   // Number of Pages Supported
-	uint64_t        logSize;          // Log Size in Bytes
-	uint64_t        pageSize;         // Page Size in Bytes
-	uint64_t        headsSupported;   // Maximum Drive Heads Supported
-	uint64_t        copies;           // Number of Historical Copies
-  uint64_t        frameCapture;     // Reason for Frame Capture
+    uint64_t        signature;        // Log Signature = 0x00004641524D4552
+    uint64_t        majorRev;         // Log Major Revision
+    uint64_t        minorRev;         // Log Rinor Revision
+    uint64_t        pagesSupported;   // Number of Pages Supported
+    uint64_t        logSize;          // Log Size in Bytes
+    uint64_t        pageSize;         // Page Size in Bytes
+    uint64_t        headsSupported;   // Maximum Drive Heads Supported
+    uint64_t        copies;           // Number of Historical Copies
+    uint64_t        frameCapture;     // Reason for Frame Capture
 } ATTR_PACKED;
 #pragma pack()
 STATIC_ASSERT(sizeof(ataFarmHeader) == 72);
@@ -622,44 +622,44 @@ STATIC_ASSERT(sizeof(ataFarmHeader) == 72);
 // Drive Information
 #pragma pack(1)
 struct ataFarmDriveInformation {
-	uint64_t        pageNumber;             // Page Number = 1
-	uint64_t        copyNumber;             // Copy Number
-	uint64_t        serialNumber;           // Serial Number [0:3]
-	uint64_t        serialNumber2;          // Serial Number [4:7]
-	uint64_t        worldWideName;          // World Wide Name [0:3]
-	uint64_t        worldWideName2;         // World Wide Name [4:7]
-	uint64_t        deviceInterface;        // Device Interface
-	uint64_t        deviceCapacity;         // 48-bit Device Capacity
-	uint64_t        psecSize;               // Physical Sector Size in Bytes
-	uint64_t        lsecSize;               // Logical Sector Size in Bytes
-	uint64_t        deviceBufferSize;       // Device Buffer Size in Bytes
-	uint64_t        heads;                  // Number of Heads
-	uint64_t        factor;                 // Device Form Factor (ID Word 168)
-	uint64_t        rotationRate;           // Rotational Rate of Device (ID Word 217)
-	uint64_t        firmwareRev;            // Firmware Revision [0:3]
-	uint64_t        firmwareRev2;           // Firmware Revision [4:7]
-	uint64_t        security;               // ATA Security State (ID Word 128)
-	uint64_t        featuresSupported;      // ATA Features Supported (ID Word 78)
-	uint64_t        featuresEnabled;        // ATA Features Enabled (ID Word 79)
-	uint64_t        poh;                    // Power-On Hours
-	uint64_t        spoh;                   // Spindle Power-On Hours
-	uint64_t        headFlightHours;        // Head Flight Hours
-	uint64_t        headLoadEvents;         // Head Load Events
-	uint64_t        powerCycleCount;        // Power Cycle Count
-	uint64_t        resetCount;             // Hardware Reset Count
-	uint64_t        spinUpTime;             // SMART Spin-Up Time in milliseconds
-	uint64_t        reserved;               // Reserved
-	uint64_t        reserved0;              // Reserved
-	uint64_t        reserved1;              // Reserved
-	uint64_t        reserved2;              // Reserved
-	uint64_t        timeToReady;			      // Time to ready of the last power cycle
-	uint64_t        timeHeld;					      // Time drive is held in staggered spin during the last power on sequence
-  uint64_t        modelNumber[10];        // Lower 32 Model Number (added 2.14)
-  uint64_t        driveRecordingType;     // 0 for SMR and 1 for CMR (added 2.15)
-  uint64_t        depopped;               // Has the drive been depopped  1 = depopped and 0 = not depopped (added 2.15)
-  uint64_t        maxNumberForReasign;    // Max Number of Available Sectors for Reassignment – Value in disc sectors (added 3.3)
-  uint64_t        dateOfAssembly;         // Date of assembly in ASCII “YYWW” where YY is the year and WW is the calendar week (added 4.2)
-  uint64_t        depopulationHeadMask;   // Depopulation Head Mask
+    uint64_t        pageNumber;             // Page Number = 1
+    uint64_t        copyNumber;             // Copy Number
+    uint64_t        serialNumber;           // Serial Number [0:3]
+    uint64_t        serialNumber2;          // Serial Number [4:7]
+    uint64_t        worldWideName;          // World Wide Name [0:3]
+    uint64_t        worldWideName2;         // World Wide Name [4:7]
+    uint64_t        deviceInterface;        // Device Interface
+    uint64_t        deviceCapacity;         // 48-bit Device Capacity
+    uint64_t        psecSize;               // Physical Sector Size in Bytes
+    uint64_t        lsecSize;               // Logical Sector Size in Bytes
+    uint64_t        deviceBufferSize;       // Device Buffer Size in Bytes
+    uint64_t        heads;                  // Number of Heads
+    uint64_t        factor;                 // Device Form Factor (ID Word 168)
+    uint64_t        rotationRate;           // Rotational Rate of Device (ID Word 217)
+    uint64_t        firmwareRev;            // Firmware Revision [0:3]
+    uint64_t        firmwareRev2;           // Firmware Revision [4:7]
+    uint64_t        security;               // ATA Security State (ID Word 128)
+    uint64_t        featuresSupported;      // ATA Features Supported (ID Word 78)
+    uint64_t        featuresEnabled;        // ATA Features Enabled (ID Word 79)
+    uint64_t        poh;                    // Power-On Hours
+    uint64_t        spoh;                   // Spindle Power-On Hours
+    uint64_t        headFlightHours;        // Head Flight Hours
+    uint64_t        headLoadEvents;         // Head Load Events
+    uint64_t        powerCycleCount;        // Power Cycle Count
+    uint64_t        resetCount;             // Hardware Reset Count
+    uint64_t        spinUpTime;             // SMART Spin-Up Time in milliseconds
+    uint64_t        reserved;               // Reserved
+    uint64_t        reserved0;              // Reserved
+    uint64_t        reserved1;              // Reserved
+    uint64_t        reserved2;              // Reserved
+    uint64_t        timeToReady;            // Time to ready of the last power cycle
+    uint64_t        timeHeld;               // Time drive is held in staggered spin during the last power on sequence
+    uint64_t        modelNumber[10];        // Lower 32 Model Number (added 2.14)
+    uint64_t        driveRecordingType;     // 0 for SMR and 1 for CMR (added 2.15)
+    uint64_t        depopped;               // Has the drive been depopped  1 = depopped and 0 = not depopped (added 2.15)
+    uint64_t        maxNumberForReasign;    // Max Number of Available Sectors for Reassignment – Value in disc sectors (added 3.3)
+    uint64_t        dateOfAssembly;         // Date of assembly in ASCII “YYWW” where YY is the year and WW is the calendar week (added 4.2)
+    uint64_t        depopulationHeadMask;   // Depopulation Head Mask
 } ATTR_PACKED;
 #pragma pack()
 STATIC_ASSERT(sizeof(ataFarmDriveInformation) == 376);
@@ -668,27 +668,27 @@ STATIC_ASSERT(sizeof(ataFarmDriveInformation) == 376);
 // Workload Statistics
 #pragma pack(1)
 struct ataFarmWorkloadStatistics {
-	uint64_t        pageNumber;               // Page Number = 2
-	uint64_t        copyNumber;               // Copy Number
-	uint64_t        reserved;                 // Reserved
-	uint64_t        totalReadCommands;        // Total Number of Read Commands
-	uint64_t        totalWriteCommands;       // Total Number of Write Commands
-	uint64_t        totalRandomReads;         // Total Number of Random Read Commands
-	uint64_t        totalRandomWrites;        // Total Number of Random Write Commands
-	uint64_t        totalNumberofOtherCMDS;   // Total Number Of Other Commands
-	uint64_t        logicalSecWritten;        // Logical Sectors Written
-	uint64_t        logicalSecRead;           // Logical Sectors Read
-  uint64_t        dither;                   // Number of dither events during current power cycle (added 3.4)
-  uint64_t        ditherRandom;             // Number of times dither was held off during random workloads during current power cycle (added 3.4)
-  uint64_t        ditherSequential;         // Number of times dither was held off during sequential workloads during current power cycle (added 3.4)
-  uint64_t        readCommandsByRadius1;    // Number of Read Commands from 0-3.125% of LBA space for last 3 SMART Summary Frames (added 4.4)
-  uint64_t        readCommandsByRadius2;    // Number of Read Commands from 3.125-25% of LBA space for last 3 SMART Summary Frames (added 4.4)
-  uint64_t        readCommandsByRadius3;    // Number of Read Commands from 25-75% of LBA space for last 3 SMART Summary Frames (added 4.4)
-  uint64_t        readCommandsByRadius4;    // Number of Read Commands from 75-100% of LBA space for last 3 SMART Summary Frames (added 4.4)
-  uint64_t        writeCommandsByRadius1;   // Number of Write Commands from 0-3.125% of LBA space for last 3 SMART Summary Frames (added 4.4)
-  uint64_t        writeCommandsByRadius2;   // Number of Write Commands from 3.125-25% of LBA space for last 3 SMART Summary Frames (added 4.4)
-  uint64_t        writeCommandsByRadius3;   // Number of Write Commands from 25-75% of LBA space for last 3 SMART Summary Frames (added 4.4)
-  uint64_t        writeCommandsByRadius4;   // Number of Write Commands from 75-100% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    uint64_t        pageNumber;               // Page Number = 2
+    uint64_t        copyNumber;               // Copy Number
+    uint64_t        reserved;                 // Reserved
+    uint64_t        totalReadCommands;        // Total Number of Read Commands
+    uint64_t        totalWriteCommands;       // Total Number of Write Commands
+    uint64_t        totalRandomReads;         // Total Number of Random Read Commands
+    uint64_t        totalRandomWrites;        // Total Number of Random Write Commands
+    uint64_t        totalNumberofOtherCMDS;   // Total Number Of Other Commands
+    uint64_t        logicalSecWritten;        // Logical Sectors Written
+    uint64_t        logicalSecRead;           // Logical Sectors Read
+    uint64_t        dither;                   // Number of dither events during current power cycle (added 3.4)
+    uint64_t        ditherRandom;             // Number of times dither was held off during random workloads during current power cycle (added 3.4)
+    uint64_t        ditherSequential;         // Number of times dither was held off during sequential workloads during current power cycle (added 3.4)
+    uint64_t        readCommandsByRadius1;    // Number of Read Commands from 0-3.125% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    uint64_t        readCommandsByRadius2;    // Number of Read Commands from 3.125-25% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    uint64_t        readCommandsByRadius3;    // Number of Read Commands from 25-75% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    uint64_t        readCommandsByRadius4;    // Number of Read Commands from 75-100% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    uint64_t        writeCommandsByRadius1;   // Number of Write Commands from 0-3.125% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    uint64_t        writeCommandsByRadius2;   // Number of Write Commands from 3.125-25% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    uint64_t        writeCommandsByRadius3;   // Number of Write Commands from 25-75% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    uint64_t        writeCommandsByRadius4;   // Number of Write Commands from 75-100% of LBA space for last 3 SMART Summary Frames (added 4.4)
 } ATTR_PACKED;
 #pragma pack()
 STATIC_ASSERT(sizeof(ataFarmWorkloadStatistics) == 168);
@@ -697,36 +697,36 @@ STATIC_ASSERT(sizeof(ataFarmWorkloadStatistics) == 168);
 // Error Statistics
 #pragma pack(1)
 struct ataFarmErrorStatistics {
-	uint64_t        pageNumber;                                 // Page Number = 3
-	uint64_t        copyNumber;                                 // Copy Number
-	uint64_t        totalUnrecoverableReadErrors;               // Number of Unrecoverable Read Errors
-	uint64_t        totalUnrecoverableWriteErrors;              // Number of Unrecoverable Write Errors
-	uint64_t        totalReallocations;                         // Number of Re-Allocated Sectors
-	uint64_t        totalReadRecoveryAttepts;                   // Number of Read Recovery Attempts
-	uint64_t        totalMechanicalStartRetries;                // Number of Mechanical Start Retries
-	uint64_t        totalReallocationCanidates;                 // Number of Re-Allocated Candidate Sectors
-	uint64_t        totalASREvents;                             // Number of ASR Events
-	uint64_t        totalCRCErrors;                             // Number of Interface CRC Errors
-	uint64_t        attrSpinRetryCount;                         // Spin Retry Count (Most recent value from array at byte 401 of attribute sector)
-	uint64_t        normalSpinRetryCount;                       // Spin Retry Count (SMART Attribute 10 Normalized)
-	uint64_t        worstSpinRretryCount;                       // Spin Retry Count (SMART Attribute 10 Worst Ever)
-	uint64_t        attrIOEDCErrors;                            // Number of IOEDC Errors (SMART Attribute 184 Raw)
-	uint64_t        attrCTOCount;                               // CTO Count Total (SMART Attribute 188 Raw[0..1])
-	uint64_t        overfiveSecCTO;                             // CTO Count Over 5s (SMART Attribute 188 Raw[2..3])
-	uint64_t        oversevenSecCTO;                            // CTO Count Over 7.5s (SMART Attribute 188 Raw[4..5])
-	uint64_t        totalFlashLED;                              // Total Flash LED (Assert) Events
-	uint64_t        indexFlashLED;                              // Index of last entry in Flash LED Info array below, in case the array wraps
-	uint64_t        uncorrectables;                             // Uncorrectable errors (SMART Attribute 187 Raw)
-  uint64_t        reserved;                                   // Reserved
-  uint64_t        flashLEDArray[8];                           // Info on the last 8 Flash LED (assert) events wrapping array (added 2.7)
-  uint64_t        reserved0[8];                               // Reserved
-  uint64_t        reserved1[2];                               // Reserved
-  uint64_t        reserved2[15];                              // Reserved
-  uint64_t        universalTimestampFlashLED[8];              // Universal Timestamp (us) of last 8 Flash LED (assert) Events, wrapping array
-  uint64_t        powerCycleFlashLED[8];                      // Power Cycle of the last 8 Flash LED (assert) Events, wrapping array
-  uint64_t        cumulativeUnrecoverableReadERC;             // Cumulative Lifetime Unrecoverable Read errors due to Error Recovery Control (e.g. ERC timeout)
-  uint64_t        cumulativeUnrecoverableReadRepeating[24];   // Cumulative Lifetime Unrecoverable Read Repeating by head
-  uint64_t        cumulativeUnrecoverableReadUnique[24];      // Cumulative Lifetime Unrecoverable Read Unique by head
+    uint64_t        pageNumber;                                 // Page Number = 3
+    uint64_t        copyNumber;                                 // Copy Number
+    uint64_t        totalUnrecoverableReadErrors;               // Number of Unrecoverable Read Errors
+    uint64_t        totalUnrecoverableWriteErrors;              // Number of Unrecoverable Write Errors
+    uint64_t        totalReallocations;                         // Number of Re-Allocated Sectors
+    uint64_t        totalReadRecoveryAttepts;                   // Number of Read Recovery Attempts
+    uint64_t        totalMechanicalStartRetries;                // Number of Mechanical Start Retries
+    uint64_t        totalReallocationCanidates;                 // Number of Re-Allocated Candidate Sectors
+    uint64_t        totalASREvents;                             // Number of ASR Events
+    uint64_t        totalCRCErrors;                             // Number of Interface CRC Errors
+    uint64_t        attrSpinRetryCount;                         // Spin Retry Count (Most recent value from array at byte 401 of attribute sector)
+    uint64_t        normalSpinRetryCount;                       // Spin Retry Count (SMART Attribute 10 Normalized)
+    uint64_t        worstSpinRretryCount;                       // Spin Retry Count (SMART Attribute 10 Worst Ever)
+    uint64_t        attrIOEDCErrors;                            // Number of IOEDC Errors (SMART Attribute 184 Raw)
+    uint64_t        attrCTOCount;                               // CTO Count Total (SMART Attribute 188 Raw[0..1])
+    uint64_t        overFiveSecCTO;                             // CTO Count Over 5s (SMART Attribute 188 Raw[2..3])
+    uint64_t        overSevenSecCTO;                            // CTO Count Over 7.5s (SMART Attribute 188 Raw[4..5])
+    uint64_t        totalFlashLED;                              // Total Flash LED (Assert) Events
+    uint64_t        indexFlashLED;                              // Index of last entry in Flash LED Info array below, in case the array wraps
+    uint64_t        uncorrectables;                             // Uncorrectable errors (SMART Attribute 187 Raw)
+    uint64_t        reserved;                                   // Reserved
+    uint64_t        flashLEDArray[8];                           // Info on the last 8 Flash LED (assert) events wrapping array (added 2.7)
+    uint64_t        reserved0[8];                               // Reserved
+    uint64_t        reserved1[2];                               // Reserved
+    uint64_t        reserved2[15];                              // Reserved
+    uint64_t        universalTimestampFlashLED[8];              // Universal Timestamp (us) of last 8 Flash LED (assert) Events, wrapping array
+    uint64_t        powerCycleFlashLED[8];                      // Power Cycle of the last 8 Flash LED (assert) Events, wrapping array
+    uint64_t        cumulativeUnrecoverableReadERC;             // Cumulative Lifetime Unrecoverable Read errors due to Error Recovery Control (e.g. ERC timeout)
+    uint64_t        cumulativeUnrecoverableReadRepeating[24];   // Cumulative Lifetime Unrecoverable Read Repeating by head
+    uint64_t        cumulativeUnrecoverableReadUnique[24];      // Cumulative Lifetime Unrecoverable Read Unique by head
 } ATTR_PACKED;
 #pragma pack()
 STATIC_ASSERT(sizeof(ataFarmErrorStatistics) == 952);
@@ -735,38 +735,38 @@ STATIC_ASSERT(sizeof(ataFarmErrorStatistics) == 952);
 // Environment Statistics
 #pragma pack(1)
 struct ataFarmEnvironmentStatistics {
-	uint64_t         pageNumber;          // Page Number = 4
-	uint64_t         copyNumber;          // Copy Number
-	uint64_t         curentTemp;          // Current Temperature in Celsius
-	uint64_t         highestTemp;         // Highest Temperature in Celsius
-	uint64_t         lowestTemp;          // Lowest Temperature in Celsius
-	uint64_t         averageTemp;         // Average Short-Term Temperature in Celsius
-	uint64_t         averageLongTemp;     // Average Long-Term Temperature in Celsius
-	uint64_t         highestShortTemp;    // Highest Average Short-Term Temperature in Celsius
-	uint64_t         lowestShortTemp;     // Lowest Average Short-Term Temperature in Celsius
-	uint64_t         highestLongTemp;     // Highest Average Long-Term Temperature in Celsius
-	uint64_t         lowestLongTemp;      // Lowest Average Long-Term Temperature in Celsius
-	uint64_t         overTempTime;        // Time In Over Temperature in Minutes
-	uint64_t         underTempTime;       // Time In Under Temperature in Minutes
-	uint64_t         maxTemp;             // Specified Max Operating Temperature in Celsius
-	uint64_t         minTemp;             // Specified Min Operating Temperature in Celsius
-	uint64_t         reserved;            // Reserved
-	uint64_t         reserved0;           // Reserved
-	uint64_t         humidity;            // Current Relative Humidity (in units of 0.1%)
-	uint64_t         reserved1;           // Reserved
-	uint64_t         currentMotorPower;   // Current Motor Power, value from most recent SMART Summary Frame
-  uint64_t         current12v;          // Current 12V input in mV (added 3.7)
-  uint64_t         min12v;              // Minimum 12V input from last 3 SMART Summary Frames in mV (added 3.7)
-  uint64_t         max12v;              // Maximum 12V input from last 3 SMART Summary Frames in mV (added 3.7)
-  uint64_t         current5v;           // Current 5V input in mV (added 3.7)
-  uint64_t         min5v;               // Minimum 5V input from last 3 SMART Summary Frames in mV (added 3.7)
-  uint64_t         max5v;               // Maximum 5V input from last 3 SMART Summary Frames in mV (added 3.7)
-  uint64_t         powerAverage12v;     // 12V Power Average (mW) - Average of last 3 SMART Summary Frames (added 4.3)
-  uint64_t         powerMin12v;         // 12V Power Min (mW) - Lowest of last 3 SMART Summary Frames (added 4.3)
-  uint64_t         powerMax12v;         // 12V Power Max (mW) - Highest of last 3 SMART Summary Frames (added 4.3)
-  uint64_t         powerAverage5v;      // 5V Power Average (mW) - Average of last 3 SMART Summary Frames (added 4.3)
-  uint64_t         powerMin5v;          // 5V Power Min (mW) - Lowest of last 3 SMART Summary Frames (added 4.3)
-  uint64_t         powerMax5v;          // 5V Power Max (mW) - Highest of last 3 SMART Summary Frames (added 4.3)
+    uint64_t         pageNumber;          // Page Number = 4
+    uint64_t         copyNumber;          // Copy Number
+    uint64_t         curentTemp;          // Current Temperature in Celsius
+    uint64_t         highestTemp;         // Highest Temperature in Celsius
+    uint64_t         lowestTemp;          // Lowest Temperature in Celsius
+    uint64_t         averageTemp;         // Average Short-Term Temperature in Celsius
+    uint64_t         averageLongTemp;     // Average Long-Term Temperature in Celsius
+    uint64_t         highestShortTemp;    // Highest Average Short-Term Temperature in Celsius
+    uint64_t         lowestShortTemp;     // Lowest Average Short-Term Temperature in Celsius
+    uint64_t         highestLongTemp;     // Highest Average Long-Term Temperature in Celsius
+    uint64_t         lowestLongTemp;      // Lowest Average Long-Term Temperature in Celsius
+    uint64_t         overTempTime;        // Time In Over Temperature in Minutes
+    uint64_t         underTempTime;       // Time In Under Temperature in Minutes
+    uint64_t         maxTemp;             // Specified Max Operating Temperature in Celsius
+    uint64_t         minTemp;             // Specified Min Operating Temperature in Celsius
+    uint64_t         reserved;            // Reserved
+    uint64_t         reserved0;           // Reserved
+    uint64_t         humidity;            // Current Relative Humidity (in units of 0.1%)
+    uint64_t         reserved1;           // Reserved
+    uint64_t         currentMotorPower;   // Current Motor Power, value from most recent SMART Summary Frame
+    uint64_t         current12v;          // Current 12V input in mV (added 3.7)
+    uint64_t         min12v;              // Minimum 12V input from last 3 SMART Summary Frames in mV (added 3.7)
+    uint64_t         max12v;              // Maximum 12V input from last 3 SMART Summary Frames in mV (added 3.7)
+    uint64_t         current5v;           // Current 5V input in mV (added 3.7)
+    uint64_t         min5v;               // Minimum 5V input from last 3 SMART Summary Frames in mV (added 3.7)
+    uint64_t         max5v;               // Maximum 5V input from last 3 SMART Summary Frames in mV (added 3.7)
+    uint64_t         powerAverage12v;     // 12V Power Average (mW) - Average of last 3 SMART Summary Frames (added 4.3)
+    uint64_t         powerMin12v;         // 12V Power Min (mW) - Lowest of last 3 SMART Summary Frames (added 4.3)
+    uint64_t         powerMax12v;         // 12V Power Max (mW) - Highest of last 3 SMART Summary Frames (added 4.3)
+    uint64_t         powerAverage5v;      // 5V Power Average (mW) - Average of last 3 SMART Summary Frames (added 4.3)
+    uint64_t         powerMin5v;          // 5V Power Min (mW) - Lowest of last 3 SMART Summary Frames (added 4.3)
+    uint64_t         powerMax5v;          // 5V Power Max (mW) - Highest of last 3 SMART Summary Frames (added 4.3)
 } ATTR_PACKED;
 #pragma pack()
 STATIC_ASSERT(sizeof(ataFarmEnvironmentStatistics) == 256);
@@ -775,69 +775,69 @@ STATIC_ASSERT(sizeof(ataFarmEnvironmentStatistics) == 256);
 // Reliability Statistics
 #pragma pack(1)
 struct ataFarmReliabilityStatistics {
-	int64_t         pageNumber;                         // Page Number = 5
-	int64_t         copyNumber;                         // Copy Number
-	uint64_t        reserved;                           // Reserved
-	uint64_t        reserved0;                          // Reserved
-  uint64_t        reserved1[24];                      // Reserved
-  uint64_t        reserved2[24];                      // Reserved
-	uint64_t        reserved3;                          // Reserved
-	uint64_t        reserved4;                          // Reserved
-	uint64_t        reserved5;                          // Reserved
-	uint64_t        reserved6;                          // Reserved
-	uint64_t        reserved7;                          // Reserved
-	uint64_t        reserved8;                          // Reserved
-	uint64_t        reserved9;                          // Reserved
-	uint64_t        reserved10;                         // Reserved
-	uint64_t        reserved11;                         // Reserved
-	uint64_t        reserved12;                         // Reserved
-	uint64_t        reserved13;                         // Reserved
-	uint64_t        reserved14[24];                     // Reserved
-	uint64_t        reserved15;                         // Reserved
-	int64_t         DVGASkipWriteDetect[24];            // [24] DVGA Skip Write Detect by Head
-	int64_t         RVGASkipWriteDetect[24];            // [24] RVGA Skip Write Detect by Head
-	int64_t         FVGASkipWriteDetect[24];            // [24] FVGA Skip Write Detect by Head
-	int64_t         skipWriteDetectThresExceeded[24];   // [24] Skip Write Detect Threshold Exceeded Count by Head
-	int64_t         attrErrorRateRaw;                   // Error Rate Raw
-	int64_t         attrErrorRateNormal;                // Error Rate Normalized
-	int64_t         attrErrorRateWorst;                 // Error Rate Worst
-	int64_t         attrSeekErrorRateRaw;               // Seek Error Rate Raw
-	int64_t         attrSeekErrorRateNormal;            // Seek Error Rate Normalized
-	int64_t         attrSeekErrorRateWorst;             // Seek Error Rate Worst
-	int64_t         attrUnloadEventsRaw;                // High Priority Unload Events 
-	uint64_t        reserved16;                         // Reserved
-	uint64_t        reserved17[24];                     // Reserved
-	uint64_t        reserved18[24];                     // Reserved
-	uint64_t        reserved19[24];                     // Reserved
-	uint64_t        reserved20[24];                     // Reserved
-	uint64_t        reserved21[24];                     // Reserved
-	uint64_t        reserved22[24];                     // Reserved
-	uint64_t        reserved23[24];                     // Reserved
-	uint64_t        reserved24[24][3];                  // Reserved
-	uint64_t        reserved25[24][3];                  // Reserved
-	uint64_t        reserved26[24];                     // Reserved
-	uint64_t        reserved27[24];                     // Reserved
-	uint64_t        reserved28[24];                     // Reserved
-	uint64_t        reserved29[24][3];                  // Reserved
-	uint64_t        reserved30;                         // Reserved
-	int64_t         reallocatedSectors[24];             // [24] Number of Reallocated Sectors per Head
-	int64_t         reallocationCandidates[24];         // [24] Number of Reallocation Candidate Sectors per Head
-	int64_t         heliumPresureTrip;                  // Helium Pressure Threshold Tripped ( 1 - trip, 0 - no trip)
-  uint64_t        reserved31[24];                     // Reserved
-  uint64_t        reserved32[24];                     // Reserved
-  uint64_t        reserved33[24];                     // Reserved
-	int64_t         writeWorkloadPowerOnTime[24];       // [24] Write Workload Power-on Time in Seconds, value from most recent SMART Summary Frame by Head
-	uint64_t        reserved34;                         // Reserved
-	uint64_t        reserved35;                         // Reserved
-	uint64_t        reserved36;                         // Reserved
-  uint64_t        reserved37[24];                     // Reserved
-  int64_t         secondMRHeadResistance[24];         // [24] Second Head, MR Head Resistance from most recent SMART Summary Frame by Head
-  uint64_t        reserved38[24];                     // Reserved
-  uint64_t        reserved39[24];                     // Reserved
-  uint64_t        reserved40[24][3];                  // Reserved
-  uint64_t        reserved41[24][3];                  // Reserved
-  uint64_t        reserved42[24][3];                  // Reserved
-	int64_t         numberLBACorrectedParitySector;     // Number of LBAs Corrected by Parity Sector
+    int64_t         pageNumber;                         // Page Number = 5
+    int64_t         copyNumber;                         // Copy Number
+    uint64_t        reserved;                           // Reserved
+    uint64_t        reserved0;                          // Reserved
+    uint64_t        reserved1[24];                      // Reserved
+    uint64_t        reserved2[24];                      // Reserved
+    uint64_t        reserved3;                          // Reserved
+    uint64_t        reserved4;                          // Reserved
+    uint64_t        reserved5;                          // Reserved
+    uint64_t        reserved6;                          // Reserved
+    uint64_t        reserved7;                          // Reserved
+    uint64_t        reserved8;                          // Reserved
+    uint64_t        reserved9;                          // Reserved
+    uint64_t        reserved10;                         // Reserved
+    uint64_t        reserved11;                         // Reserved
+    uint64_t        reserved12;                         // Reserved
+    uint64_t        reserved13;                         // Reserved
+    uint64_t        reserved14[24];                     // Reserved
+    uint64_t        reserved15;                         // Reserved
+    int64_t         DVGASkipWriteDetect[24];            // [24] DVGA Skip Write Detect by Head
+    int64_t         RVGASkipWriteDetect[24];            // [24] RVGA Skip Write Detect by Head
+    int64_t         FVGASkipWriteDetect[24];            // [24] FVGA Skip Write Detect by Head
+    int64_t         skipWriteDetectThresExceeded[24];   // [24] Skip Write Detect Threshold Exceeded Count by Head
+    int64_t         attrErrorRateRaw;                   // Error Rate Raw
+    int64_t         attrErrorRateNormal;                // Error Rate Normalized
+    int64_t         attrErrorRateWorst;                 // Error Rate Worst
+    int64_t         attrSeekErrorRateRaw;               // Seek Error Rate Raw
+    int64_t         attrSeekErrorRateNormal;            // Seek Error Rate Normalized
+    int64_t         attrSeekErrorRateWorst;             // Seek Error Rate Worst
+    int64_t         attrUnloadEventsRaw;                // High Priority Unload Events 
+    uint64_t        reserved16;                         // Reserved
+    uint64_t        reserved17[24];                     // Reserved
+    uint64_t        reserved18[24];                     // Reserved
+    uint64_t        reserved19[24];                     // Reserved
+    uint64_t        mrHeadResistance[24];               // MR Head Resistance from most recent SMART Summary Frame by Head 
+    uint64_t        reserved21[24];                     // Reserved
+    uint64_t        reserved22[24];                     // Reserved
+    uint64_t        reserved23[24];                     // Reserved
+    uint64_t        reserved24[24][3];                  // Reserved
+    uint64_t        reserved25[24][3];                  // Reserved
+    uint64_t        reserved26[24];                     // Reserved
+    uint64_t        reserved27[24];                     // Reserved
+    int64_t         reserved28[24];                     // Reserved
+    int64_t         reserved29[24][3];                  // Reserved
+    uint64_t        reserved30;                         // Reserved
+    int64_t         reallocatedSectors[24];             // [24] Number of Reallocated Sectors per Head
+    int64_t         reallocationCandidates[24];         // [24] Number of Reallocation Candidate Sectors per Head
+    int64_t         heliumPresureTrip;                  // Helium Pressure Threshold Tripped ( 1 - trip, 0 - no trip)
+    uint64_t        reserved31[24];                     // Reserved
+    uint64_t        reserved32[24];                     // Reserved
+    uint64_t        reserved33[24];                     // Reserved
+    int64_t         writeWorkloadPowerOnTime[24];       // [24] Write Workload Power-on Time in Seconds, value from most recent SMART Summary Frame by Head
+    uint64_t        reserved34;                         // Reserved
+    uint64_t        reserved35;                         // Reserved
+    uint64_t        reserved36;                         // Reserved
+    uint64_t        reserved37[24];                     // Reserved
+    int64_t         secondMRHeadResistance[24];         // [24] Second Head, MR Head Resistance from most recent SMART Summary Frame by Head
+    uint64_t        reserved38[24];                     // Reserved
+    uint64_t        reserved39[24];                     // Reserved
+    uint64_t        reserved40[24][3];                  // Reserved
+    uint64_t        reserved41[24][3];                  // Reserved
+    uint64_t        reserved42[24][3];                  // Reserved
+    int64_t         numberLBACorrectedParitySector;     // Number of LBAs Corrected by Parity Sector
 } ATTR_PACKED;
 #pragma pack()
 STATIC_ASSERT(sizeof(ataFarmReliabilityStatistics) == 8880);
@@ -845,12 +845,12 @@ STATIC_ASSERT(sizeof(ataFarmReliabilityStatistics) == 8880);
 // Seagate Field Access Reliability Metrics log (FARM) all pages
 #pragma pack(1)
 struct ataFarmLog {
-  ataFarmHeader                       headerPage;             // Log Header page
-	ataFarmDriveInformation             driveInformationPage;   // Drive Information page
-	ataFarmWorkloadStatistics           workloadPage;           // Workload Statistics page
-	ataFarmErrorStatistics              errorPage;              // Error Statistics page
-	ataFarmEnvironmentStatistics        environmentPage;        // Environment Statistics page 
-	ataFarmReliabilityStatistics        reliabilityPage;        // Reliability Statistics page
+    ataFarmHeader                       header;             // Log Header page
+    ataFarmDriveInformation             driveInformation;   // Drive Information page
+    ataFarmWorkloadStatistics           workload;           // Workload Statistics page
+    ataFarmErrorStatistics              error;              // Error Statistics page
+    ataFarmEnvironmentStatistics        environment;        // Environment Statistics page 
+    ataFarmReliabilityStatistics        reliability;        // Reliability Statistics page
 } ATTR_PACKED;
 #pragma pack()
 STATIC_ASSERT(sizeof(ataFarmLog) == 72 + 376 + 168 + 952 + 256 + 8880);

--- a/smartmontools/ataprint.cpp
+++ b/smartmontools/ataprint.cpp
@@ -2122,6 +2122,22 @@ static void PrintSataPhyEventCounters(const unsigned char * data, bool reset)
 // Seagate Field Access Reliability Metrics (FARM) log (Log 0xA6)
 
 /*
+ *  Simple max element function helper for printing Seagate FARM Logs
+ *  
+ * @param   Array with metric values (uint64_t [])
+ * @return  Maximum value of given array (uint64_t)
+ */
+static uint64_t getMaxValFARM(uint64_t arr[]) {
+  uint64_t currentMax = 0;
+  for (unsigned i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
+    if (arr[i] > currentMax) {
+        currentMax = arr[i];
+    }
+  }
+  return currentMax;
+}
+
+/*
  *  Reads vendor-specific FARM log (GP Log 0xA6) data from Seagate
  *  drives and parses data into FARM log structures
  *  Returns parsed structure as defined in atacmds.h
@@ -2186,27 +2202,27 @@ static ataFarmLog * ataReadFarmLog(ata_device * device, unsigned nsectors) {
     // Check number of sectors to read for next page
     switch (page) {
     case 0:
-      memcpy(&ptr_farmLog->headerPage, currentFarmLogPage, sizeof(ataFarmHeader));
+      memcpy(&ptr_farmLog->header, currentFarmLogPage, sizeof(ataFarmHeader));
       numSectorsToRead = (sizeof(ataFarmDriveInformation) / FARM_SECTOR_SIZE) + 1;
       break;
     case 1:
-      memcpy(&ptr_farmLog->driveInformationPage, currentFarmLogPage, sizeof(ataFarmDriveInformation));
+      memcpy(&ptr_farmLog->driveInformation, currentFarmLogPage, sizeof(ataFarmDriveInformation));
       numSectorsToRead = (sizeof(ataFarmWorkloadStatistics) / FARM_SECTOR_SIZE) + 1;
       break;
     case 2:
-      memcpy(&ptr_farmLog->workloadPage, currentFarmLogPage, sizeof(ataFarmWorkloadStatistics));
+      memcpy(&ptr_farmLog->workload, currentFarmLogPage, sizeof(ataFarmWorkloadStatistics));
       numSectorsToRead = (sizeof(ataFarmErrorStatistics) / FARM_SECTOR_SIZE) + 1;
       break;
     case 3:
-      memcpy(&ptr_farmLog->errorPage, currentFarmLogPage, sizeof(ataFarmErrorStatistics));
+      memcpy(&ptr_farmLog->error, currentFarmLogPage, sizeof(ataFarmErrorStatistics));
       numSectorsToRead = (sizeof(ataFarmEnvironmentStatistics) / FARM_SECTOR_SIZE) + 1;
       break;
     case 4:
-      memcpy(&ptr_farmLog->environmentPage, currentFarmLogPage, sizeof(ataFarmEnvironmentStatistics));
+      memcpy(&ptr_farmLog->environment, currentFarmLogPage, sizeof(ataFarmEnvironmentStatistics));
       numSectorsToRead = (sizeof(ataFarmReliabilityStatistics) / FARM_SECTOR_SIZE) + 1;
       break;
     case 5:
-      memcpy(&ptr_farmLog->reliabilityPage, currentFarmLogPage, sizeof(ataFarmReliabilityStatistics));
+      memcpy(&ptr_farmLog->reliability, currentFarmLogPage, sizeof(ataFarmReliabilityStatistics));
       break;
     }
   }
@@ -2230,40 +2246,110 @@ static bool ataPrintFarmLog(ataFarmLog * ptr_farmLog) {
   }
   // Print plain-text
   jout("\nSeagate Field Access Reliability Metrics log (FARM) (GP log 0xA6)\n");
-  jout("FARM Log Major Revision: %lu\n", ptr_farmLog->headerPage.majorRev);
-  jout("FARM Log Minor Revision: %lu\n", ptr_farmLog->headerPage.minorRev);
-  jout("Number of Unrecoverable Read Errors: %lu\n", ptr_farmLog->errorPage.totalUnrecoverableReadErrors);
-  jout("Number of Unrecoverable Write Errors: %lu\n",ptr_farmLog->errorPage.totalUnrecoverableWriteErrors);
-  jout("Number of Reallocated Sectors: %lu\n", ptr_farmLog->errorPage.totalReallocations);
-  jout("Number of Read Recovery Attempts: %lu\n", ptr_farmLog->errorPage.totalReadRecoveryAttepts);
-  jout("Number of Mechanical Start Failures: %lu\n", ptr_farmLog->errorPage.totalMechanicalStartRetries);
-  jout("Number of IOEDC Errors: %lu\n", ptr_farmLog->errorPage.attrIOEDCErrors);
-  jout("Error Rate (Normalized): %li\n", ptr_farmLog->reliabilityPage.attrErrorRateNormal);
-  jout("Seek Error Rate (Normalized): %li\n", ptr_farmLog->reliabilityPage.attrSeekErrorRateNormal);
-  jout("Current 12V Input (mV): %lu\n", ptr_farmLog->environmentPage.current12v);
-  jout("Minimum 12V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environmentPage.min12v);
-  jout("Maximum 12V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environmentPage.max12v);
-  jout("Current 5V Input (mV): %lu\n", ptr_farmLog->environmentPage.current5v);
-  jout("Minimum 5V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environmentPage.min5v);
-  jout("Maximum 5V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environmentPage.max5v);
+  // Page 0: Log Header
+  jout("\tFARM Log Page 0: Log Header\n");
+  jout("\t\tFARM Log Major Revision: %lu\n", ptr_farmLog->header.majorRev);
+  jout("\t\tFARM Log Minor Revision: %lu\n", ptr_farmLog->header.minorRev);
+  // Page 1: Drive Information
+  jout("\tFARM Log Page 1: Drive Information\n");
+  jout("\t\tHead Load Events: %lu\n", ptr_farmLog->driveInformation.headLoadEvents);
+  // Page 2: Workload Statistics
+  jout("\tFARM Log Page 2: Workload Statistics\n");
+  // Page 3: Error Statistics
+  jout("\tFARM Log Page 3: Error Statistics\n");
+  jout("\t\tNumber of Unrecoverable Read Errors: %lu\n", ptr_farmLog->error.totalUnrecoverableReadErrors);
+  jout("\t\tNumber of Unrecoverable Write Errors: %lu\n",ptr_farmLog->error.totalUnrecoverableWriteErrors);
+  jout("\t\tNumber of Reallocated Sectors: %lu\n", ptr_farmLog->error.totalReallocations);
+  jout("\t\tNumber of Reallocated Candidate Sectors: %lu\n", ptr_farmLog->error.totalReallocationCanidates);
+  jout("\t\tNumber of Read Recovery Attempts: %lu\n", ptr_farmLog->error.totalReadRecoveryAttepts);
+  jout("\t\tNumber of Mechanical Start Failures: %lu\n", ptr_farmLog->error.totalMechanicalStartRetries);
+  jout("\t\tNumber of IOEDC Errors: %lu\n", ptr_farmLog->error.attrIOEDCErrors);
+  jout("\t\tCommand Time-Out Count Total: %lu\n", ptr_farmLog->error.attrCTOCount);
+  jout("\t\tCommand Time-Out Over 5 Seconds Count: %lu\n", ptr_farmLog->error.overFiveSecCTO);
+  jout("\t\tCommand Time-Out Over 7 Seconds Count: %lu\n", ptr_farmLog->error.overSevenSecCTO);
+  // Page 4: Environment Statistics
+  jout("\tFARM Log Page 4: Environment Statistics\n");
+  jout("\t\tCurrent 12V Input (mV): %lu\n", ptr_farmLog->environment.current12v);
+  jout("\t\tMinimum 12V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environment.min12v);
+  jout("\t\tMaximum 12V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environment.max12v);
+  jout("\t\tCurrent 5V Input (mV): %lu\n", ptr_farmLog->environment.current5v);
+  jout("\t\tMinimum 5V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environment.min5v);
+  jout("\t\tMaximum 5V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environment.max5v);
+  jout("\t\t12V Power Average (mW): %lu\n", ptr_farmLog->environment.powerAverage12v);
+  // Page 5: Reliability Statistics
+  jout("\tFARM Log Page 5: Reliability Statistics\n");
+  jout("\t\tError Rate (Normalized): %li\n", ptr_farmLog->reliability.attrErrorRateNormal);
+  jout("\t\tError Rate (Worst): %li\n", ptr_farmLog->reliability.attrErrorRateWorst);
+  jout("\t\tSeek Error Rate (Normalized): %li\n", ptr_farmLog->reliability.attrSeekErrorRateNormal);
+  jout("\t\tSeek Error Rate (Worst): %li\n", ptr_farmLog->reliability.attrSeekErrorRateWorst);
+  jout("\t\tHigh Priority Unload Events: %li\n", ptr_farmLog->reliability.attrUnloadEventsRaw);
+  jout("\t\tLBAs Corrected: %li\n", ptr_farmLog->reliability.numberLBACorrectedParitySector);
+  // Private metrics
+  jout("\tFARM Log: Private Metrics\n");
+  jout("\t\tPrivate Metric 5-504: %lu\n", getMaxValFARM(ptr_farmLog->reliability.reserved14));
+  jout("\t\tPrivate Metric 5-1528: %lu\n", ptr_farmLog->reliability.reserved16);
+  jout("\t\tPrivate Metric 5-2688: %lu\n", getMaxValFARM(ptr_farmLog->reliability.reserved23));
+  jout("\t\tPrivate Metric 5-2880: %lu\n", getMaxValFARM(ptr_farmLog->reliability.reserved24[0]));
+  jout("\t\tPrivate Metric 5-3072: %lu\n", getMaxValFARM(ptr_farmLog->reliability.reserved24[1]));
+  jout("\t\tPrivate Metric 5-3264: %lu\n", getMaxValFARM(ptr_farmLog->reliability.reserved24[2]));
+  jout("\t\tPrivate Metric 5-3456: %lu\n", getMaxValFARM(ptr_farmLog->reliability.reserved25[0]));
+  jout("\t\tPrivate Metric 5-3648: %lu\n", getMaxValFARM(ptr_farmLog->reliability.reserved25[1]));
+  jout("\t\tPrivate Metric 5-3840: %lu\n", getMaxValFARM(ptr_farmLog->reliability.reserved25[2]));
+  jout("\t\tPrivate Metric 5-4032: %lu\n", getMaxValFARM(ptr_farmLog->reliability.reserved26));
+  jout("\t\tPrivate Metric 5-5184: %lu\n", ptr_farmLog->reliability.reserved30);
   // Print JSON if --json or -j is specified
   json::ref jref = jglb["seagate_farm_log"];
-  jref["log_major_revision"] = ptr_farmLog->headerPage.majorRev;
-  jref["log_minor_revision"] = ptr_farmLog->headerPage.minorRev;
-  jref["number_of_unrecoverable_read_errors"] = ptr_farmLog->errorPage.totalUnrecoverableReadErrors;
-  jref["number_of_unrecoverable_write_errors"] = ptr_farmLog->errorPage.totalUnrecoverableWriteErrors;
-  jref["number_of_reallocated_sectors"] = ptr_farmLog->errorPage.totalReallocations;
-  jref["number_of_read_recovery_attempts"] = ptr_farmLog->errorPage.totalReadRecoveryAttepts;
-  jref["number_of_mechanical_start_failures"] = ptr_farmLog->errorPage.totalMechanicalStartRetries;
-  jref["number_of_ioedc_errors"] = ptr_farmLog->errorPage.attrIOEDCErrors;
-  jref["error_rate_normalized"] = ptr_farmLog->reliabilityPage.attrErrorRateNormal;
-  jref["seek_error_rate_normalized"] = ptr_farmLog->reliabilityPage.attrSeekErrorRateNormal;
-  jref["current_12_volt_input_in_mv"] = ptr_farmLog->environmentPage.current12v;
-  jref["minimum_12_volt_input_in_mv"] = ptr_farmLog->environmentPage.min12v;
-  jref["maximum_12_volt_input_in_mv"] = ptr_farmLog->environmentPage.max12v;
-  jref["current_5_volt_input_in_mv"] = ptr_farmLog->environmentPage.current5v;
-  jref["minimum_5_volt_input_in_mv"] = ptr_farmLog->environmentPage.min5v;
-  jref["maximum_5_volt_input_in_mv"] = ptr_farmLog->environmentPage.max5v;
+  // Page 0: Log Header
+  json::ref jref0 = jref["page_0_log_header"];
+  jref0["log_major_revision"] = ptr_farmLog->header.majorRev;
+  jref0["log_minor_revision"] = ptr_farmLog->header.minorRev;
+  // Page 1: Drive Information
+  json::ref jref1 = jref["page_1_drive_information"];
+  jref1["head_load_events"] = ptr_farmLog->driveInformation.headLoadEvents;
+  // Page 2: Workload Statistics
+  json::ref jref2 = jref["page_2_workload_statistics"];
+  // Page 3: Error Statistics
+  json::ref jref3 = jref["page_3_error_statistics"];
+  jref3["number_of_unrecoverable_read_errors"] = ptr_farmLog->error.totalUnrecoverableReadErrors;
+  jref3["number_of_unrecoverable_write_errors"] = ptr_farmLog->error.totalUnrecoverableWriteErrors;
+  jref3["number_of_reallocated_sectors"] = ptr_farmLog->error.totalReallocations;
+  jref3["number_of_reallocated_candidate_sectors"] = ptr_farmLog->error.totalReallocationCanidates;
+  jref3["number_of_read_recovery_attempts"] = ptr_farmLog->error.totalReadRecoveryAttepts;
+  jref3["number_of_mechanical_start_failures"] = ptr_farmLog->error.totalMechanicalStartRetries;
+  jref3["number_of_ioedc_errors"] = ptr_farmLog->error.attrIOEDCErrors;
+  jref3["command_time_out_count_total"] = ptr_farmLog->error.attrCTOCount;
+  jref3["command_time_out_over_5_seconds_count"] = ptr_farmLog->error.overFiveSecCTO;
+  jref3["command_time_out_over_7_seconds_count"] = ptr_farmLog->error.overSevenSecCTO;
+  // Page 4: Environment Statistics
+  json::ref jref4 = jref["page_4_environment_statistics"];
+  jref4["current_12_volt_input_in_mv"] = ptr_farmLog->environment.current12v;
+  jref4["minimum_12_volt_input_in_mv"] = ptr_farmLog->environment.min12v;
+  jref4["maximum_12_volt_input_in_mv"] = ptr_farmLog->environment.max12v;
+  jref4["current_5_volt_input_in_mv"] = ptr_farmLog->environment.current5v;
+  jref4["minimum_5_volt_input_in_mv"] = ptr_farmLog->environment.min5v;
+  jref4["maximum_5_volt_input_in_mv"] = ptr_farmLog->environment.max5v;
+  jref4["twelve_volt_power_average_in_mw"] = ptr_farmLog->environment.powerAverage12v;
+  // Page 5: Reliability Statistics
+  json::ref jref5 = jref["page_5_reliability_statistics"];
+  jref5["error_rate_normalized"] = ptr_farmLog->reliability.attrErrorRateNormal;
+  jref5["error_rate_worst"] = ptr_farmLog->reliability.attrErrorRateWorst;
+  jref5["seek_error_rate_normalized"] = ptr_farmLog->reliability.attrSeekErrorRateNormal;
+  jref5["seek_error_rate_worst"] = ptr_farmLog->reliability.attrSeekErrorRateWorst;
+  jref5["lbas_corrected"] = ptr_farmLog->reliability.numberLBACorrectedParitySector;
+  jref5["high_priority_unload_events"] = ptr_farmLog->reliability.attrUnloadEventsRaw;
+  // Private metrics
+  json::ref jrefp = jref["private_metrics"];
+  jrefp["private_metric_5_504"] = getMaxValFARM(ptr_farmLog->reliability.reserved14);
+  jrefp["private_metric_5_1528"] = ptr_farmLog->reliability.reserved16;
+  jrefp["private_metric_5_2688"] = getMaxValFARM(ptr_farmLog->reliability.reserved23);
+  jrefp["private_metric_5_2880"] = getMaxValFARM(ptr_farmLog->reliability.reserved24[0]);
+  jrefp["private_metric_5_3072"] = getMaxValFARM(ptr_farmLog->reliability.reserved24[1]);
+  jrefp["private_metric_5_3264"] = getMaxValFARM(ptr_farmLog->reliability.reserved24[2]);
+  jrefp["private_metric_5_3456"] = getMaxValFARM(ptr_farmLog->reliability.reserved25[0]);
+  jrefp["private_metric_5_3648"] = getMaxValFARM(ptr_farmLog->reliability.reserved25[1]);
+  jrefp["private_metric_5_3840"] = getMaxValFARM(ptr_farmLog->reliability.reserved25[2]);
+  jrefp["private_metric_5_4032"] = getMaxValFARM(ptr_farmLog->reliability.reserved26);
+  jrefp["private_metric_5_5184"] = ptr_farmLog->reliability.reserved30;
   return true;
 }
 

--- a/smartmontools/ataprint.cpp
+++ b/smartmontools/ataprint.cpp
@@ -4643,22 +4643,30 @@ int ataPrintMain (ata_device * device, const ata_print_options & options)
     if (isSeagate(&drive)) {
       unsigned nsectors = GetNumLogSectors(gplogdir, 0xA6, true);
       if (!nsectors) {
-        pout("FARM log (GP Log 0xA6) not supported\n\n");
+        if (!options.all) {
+          pout("FARM log (GP Log 0xA6) not supported\n\n");
+        }
       } else {
         ataFarmLog * ptr_farmLog = ataReadFarmLog(device, nsectors);
         if (ptr_farmLog == NULL) {
-          pout("Read FARM log (GP Log 0xA6) failed\n\n");
+          if (!options.all) {
+            pout("Read FARM log (GP Log 0xA6) failed\n\n");
+          }
           failuretest(OPTIONAL_CMD, returnval|=FAILSMART);
         } else {
           if (!ataPrintFarmLog(ptr_farmLog)) {
-            pout("Print FARM log (GP Log 0xA6) failed\n\n");
+            if (!options.all) {
+              pout("Print FARM log (GP Log 0xA6) failed\n\n");
+            }
           }
         }
         delete ptr_farmLog;
         ptr_farmLog = NULL;
       }
     } else {
-      pout("FARM log (GP Log 0xA6) not supported for non-Seagate drives\n\n");
+      if (!options.all) {
+        pout("FARM log (GP Log 0xA6) not supported for non-Seagate drives\n\n");
+      }
     }
   }
   // Set to standby (spindown) mode and set standby timer if not done above

--- a/smartmontools/ataprint.cpp
+++ b/smartmontools/ataprint.cpp
@@ -2144,8 +2144,8 @@ static ataFarmLog * ataReadFarmLog(ata_device * device, unsigned nsectors) {
     sizeof(ataFarmErrorStatistics),
     sizeof(ataFarmEnvironmentStatistics),
     sizeof(ataFarmReliabilityStatistics)};
-  ataFarmLog farmLog;
-  ataFarmLog * ptr_farmLog = &farmLog;
+  ataFarmLog * ptr_farmLog = new ataFarmLog;
+  memset(ptr_farmLog, 0, sizeof(ataFarmLog));
   unsigned numSectorsToRead = (sizeof(ataFarmHeader) / FARM_SECTOR_SIZE) + 1;
   // Go through each of the six pages of the FARM log
   for (unsigned page = 0; page < FARM_MAX_PAGES; page++) {
@@ -4654,6 +4654,8 @@ int ataPrintMain (ata_device * device, const ata_print_options & options)
             pout("Print FARM log (GP Log 0xA6) failed\n\n");
           }
         }
+        delete ptr_farmLog;
+        ptr_farmLog = NULL;
       }
     } else {
       pout("FARM log (GP Log 0xA6) not supported for non-Seagate drives\n\n");

--- a/smartmontools/ataprint.cpp
+++ b/smartmontools/ataprint.cpp
@@ -2368,7 +2368,7 @@ static bool ataPrintFarmLog(ataFarmLog * ptr_farmLog) {
   jref5["error_rate_worst"] = ptr_farmLog->reliability.attrErrorRateWorst;
   jref5["seek_error_rate_normalized"] = ptr_farmLog->reliability.attrSeekErrorRateNormal;
   jref5["seek_error_rate_worst"] = ptr_farmLog->reliability.attrSeekErrorRateWorst;
-  jref5["lbas_corrected_by_parity_sector.0"] = ptr_farmLog->reliability.numberLBACorrectedParitySector;
+  jref5["lbas_corrected_by_parity_sector"] = ptr_farmLog->reliability.numberLBACorrectedParitySector;
   jref5["high_priority_unload_events"] = ptr_farmLog->reliability.attrUnloadEventsRaw;
   // Private metrics
   json::ref jrefp = jref["private_metrics"];

--- a/smartmontools/ataprint.cpp
+++ b/smartmontools/ataprint.cpp
@@ -2266,13 +2266,13 @@ static bool ataPrintFarmLog(ataFarmLog * ptr_farmLog) {
   jout("\nSeagate Field Access Reliability Metrics log (FARM) (GP log 0xA6)\n");
   // Page 0: Log Header
   jout("\tFARM Log Page 0: Log Header\n");
-  jout("\t\tFARM Log Major Revision: %lu\n", ptr_farmLog->header.majorRev);
-  jout("\t\tFARM Log Minor Revision: %lu\n", ptr_farmLog->header.minorRev);
+  jout("\t\tFARM Log Version: %lu.%lu\n", ptr_farmLog->header.majorRev, ptr_farmLog->header.minorRev);
   // Page 1: Drive Information
   jout("\tFARM Log Page 1: Drive Information\n");
   jout("\t\tHead Load Events: %lu\n", ptr_farmLog->driveInformation.headLoadEvents);
   // Page 2: Workload Statistics
   jout("\tFARM Log Page 2: Workload Statistics\n");
+  jout("\n");
   // Page 3: Error Statistics
   jout("\tFARM Log Page 3: Error Statistics\n");
   jout("\t\tNumber of Unrecoverable Read Errors: %lu\n", ptr_farmLog->error.totalUnrecoverableReadErrors);
@@ -2301,7 +2301,7 @@ static bool ataPrintFarmLog(ataFarmLog * ptr_farmLog) {
   jout("\t\tSeek Error Rate (Normalized): %li\n", ptr_farmLog->reliability.attrSeekErrorRateNormal);
   jout("\t\tSeek Error Rate (Worst): %li\n", ptr_farmLog->reliability.attrSeekErrorRateWorst);
   jout("\t\tHigh Priority Unload Events: %li\n", ptr_farmLog->reliability.attrUnloadEventsRaw);
-  jout("\t\tLBAs Corrected: %li\n", ptr_farmLog->reliability.numberLBACorrectedParitySector);
+  jout("\t\tLBAs Corrected By Parity Sector: %li\n", ptr_farmLog->reliability.numberLBACorrectedParitySector);
   // Private metrics
   jout("\tFARM Log: Private Metrics\n");
   jout("\t\tPrivate Metric 5-504: %lu\n", getMaxValFARM(ptr_farmLog->reliability.reserved14, n));
@@ -2330,11 +2330,12 @@ static bool ataPrintFarmLog(ataFarmLog * ptr_farmLog) {
   jout("\t\tPrivate Metric 5-4032: %lu\n", getMaxValFARM(ptr_farmLog->reliability.reserved26, n));
   jout("\t\tPrivate Metric 5-5184: %lu\n", ptr_farmLog->reliability.reserved30);
   // Print JSON if --json or -j is specified
+  char str[50];
   json::ref jref = jglb["seagate_farm_log"];
   // Page 0: Log Header
   json::ref jref0 = jref["page_0_log_header"];
-  jref0["log_major_revision"] = ptr_farmLog->header.majorRev;
-  jref0["log_minor_revision"] = ptr_farmLog->header.minorRev;
+  sprintf(str, "%lu.%lu", ptr_farmLog->header.majorRev, ptr_farmLog->header.minorRev);
+  jref0["farm_log_version"] = str;
   // Page 1: Drive Information
   json::ref jref1 = jref["page_1_drive_information"];
   jref1["head_load_events"] = ptr_farmLog->driveInformation.headLoadEvents;
@@ -2367,43 +2368,36 @@ static bool ataPrintFarmLog(ataFarmLog * ptr_farmLog) {
   jref5["error_rate_worst"] = ptr_farmLog->reliability.attrErrorRateWorst;
   jref5["seek_error_rate_normalized"] = ptr_farmLog->reliability.attrSeekErrorRateNormal;
   jref5["seek_error_rate_worst"] = ptr_farmLog->reliability.attrSeekErrorRateWorst;
-  jref5["lbas_corrected"] = ptr_farmLog->reliability.numberLBACorrectedParitySector;
+  jref5["lbas_corrected_by_parity_sector.0"] = ptr_farmLog->reliability.numberLBACorrectedParitySector;
   jref5["high_priority_unload_events"] = ptr_farmLog->reliability.attrUnloadEventsRaw;
   // Private metrics
   json::ref jrefp = jref["private_metrics"];
+  jrefp["private_metric_5_488"] = ptr_farmLog->reliability.reserved12;
   jrefp["private_metric_5_504"] = getMaxValFARM(ptr_farmLog->reliability.reserved14, n);
   jrefp["private_metric_5_1528"] = ptr_farmLog->reliability.reserved16;
   jrefp["private_metric_5_2688"] = getMaxValFARM(ptr_farmLog->reliability.reserved23, n);
-  double val;
-  char str[50];
   arr = constructColArr(ptr_farmLog->reliability.reserved24, 0, n);
-  val = getMaxValFARM(arr, n) * 0.1;
-  sprintf(str,"%0.01f", val);
+  sprintf(str, "%0.01f", (double) getMaxValFARM(arr, n) * 0.1);
   delete [] arr;
   jrefp["private_metric_5_2880i"] = str;
   arr = constructColArr(ptr_farmLog->reliability.reserved24, 1, n);
-  val = getMaxValFARM(arr, n) * 0.1;
-  sprintf(str,"%0.01f", val);
+  sprintf(str, "%0.01f", (double) getMaxValFARM(arr, n) * 0.1);
   delete [] arr;
   jrefp["private_metric_5_2880m"] = str;
   arr = constructColArr(ptr_farmLog->reliability.reserved24, 2, n);
-  val = getMaxValFARM(arr, n) * 0.1;
-  sprintf(str,"%0.01f", val);
+  sprintf(str, "%0.01f", (double) getMaxValFARM(arr, n) * 0.1);
   delete [] arr;
   jrefp["private_metric_5_2880o"] = str;
   arr = constructColArr(ptr_farmLog->reliability.reserved25, 0, n);
-  val = getMaxValFARM(arr, n) * 0.1;
-  sprintf(str,"%0.01f", val);
+  sprintf(str, "%0.01f", (double) getMaxValFARM(arr, n) * 0.1);
   delete [] arr;
   jrefp["private_metric_5_3456i"] = str;
   arr = constructColArr(ptr_farmLog->reliability.reserved25, 1, n);
-  val = getMaxValFARM(arr, n) * 0.1;
-  sprintf(str,"%0.01f", val);
+  sprintf(str, "%0.01f", (double) getMaxValFARM(arr, n) * 0.1);
   delete [] arr;
   jrefp["private_metric_5_3456m"] = str;
   arr = constructColArr(ptr_farmLog->reliability.reserved25, 2, n);
-  val = getMaxValFARM(arr, n) * 0.1;
-  sprintf(str,"%0.01f", val);
+  sprintf(str, "%0.01f", (double) getMaxValFARM(arr, n) * 0.1);
   delete [] arr;
   jrefp["private_metric_5_3456o"] = str;
   arr = NULL;

--- a/smartmontools/ataprint.cpp
+++ b/smartmontools/ataprint.cpp
@@ -4644,19 +4644,25 @@ int ataPrintMain (ata_device * device, const ata_print_options & options)
       unsigned nsectors = GetNumLogSectors(gplogdir, 0xA6, true);
       if (!nsectors) {
         if (!options.all) {
-          pout("FARM log (GP Log 0xA6) not supported\n\n");
+          jout("\nFARM log (GP Log 0xA6) not supported\n\n");
+          json::ref js = jglb["seagate_farm_log_supported"];
+          js = false;
         }
       } else {
         ataFarmLog * ptr_farmLog = ataReadFarmLog(device, nsectors);
         if (ptr_farmLog == NULL) {
           if (!options.all) {
-            pout("Read FARM log (GP Log 0xA6) failed\n\n");
+            jout("\nRead FARM log (GP Log 0xA6) failed\n\n");
+            json::ref js = jglb["seagate_farm_log_supported"];
+            js = false;
           }
           failuretest(OPTIONAL_CMD, returnval|=FAILSMART);
         } else {
           if (!ataPrintFarmLog(ptr_farmLog)) {
             if (!options.all) {
-              pout("Print FARM log (GP Log 0xA6) failed\n\n");
+              jout("\nPrint FARM log (GP Log 0xA6) failed\n\n");
+              json::ref js = jglb["seagate_farm_log_supported"];
+              js = false;
             }
           }
         }
@@ -4665,7 +4671,9 @@ int ataPrintMain (ata_device * device, const ata_print_options & options)
       }
     } else {
       if (!options.all) {
-        pout("FARM log (GP Log 0xA6) not supported for non-Seagate drives\n\n");
+        jout("FARM log (GP Log 0xA6) not supported for non-Seagate drives\n\n");
+        json::ref js = jglb["seagate_farm_log_supported"];
+        js = false;
       }
     }
   }

--- a/smartmontools/ataprint.h
+++ b/smartmontools/ataprint.h
@@ -42,7 +42,8 @@ struct ata_print_options
   bool smart_selftest_log;
   bool smart_selective_selftest_log;
 
-  bool farm_log; // Seagate Field Access Reliability Metrics log (FARM) for ATA
+  bool farm_log;    // Seagate Field Access Reliability Metrics log (FARM) for ATA
+  bool all;         // Helper for FARM debug messages
 
   bool gp_logdir, smart_logdir;
   unsigned smart_ext_error_log;
@@ -118,6 +119,7 @@ struct ata_print_options
       smart_selftest_log(false),
       smart_selective_selftest_log(false),
       farm_log(false),
+      all(false),
       gp_logdir(false), smart_logdir(false),
       smart_ext_error_log(0),
       smart_ext_selftest_log(0),

--- a/smartmontools/scsicmds.h
+++ b/smartmontools/scsicmds.h
@@ -175,8 +175,8 @@ struct scsi_readcap_resp {
 #pragma pack(1)
 struct scsiFarmPageHeader {
     uint8_t             pageCode;       // Page Code (0x3D)
-	uint8_t             subpageCode;    // Sub-Page Code (0x03)
-	uint16_t            pageLength;     // Page Length
+    uint8_t             subpageCode;    // Sub-Page Code (0x03)
+    uint16_t            pageLength;     // Page Length
 } ATTR_PACKED;
 #pragma pack()
 STATIC_ASSERT(sizeof(scsiFarmPageHeader) == 4);
@@ -185,9 +185,9 @@ STATIC_ASSERT(sizeof(scsiFarmPageHeader) == 4);
 // Parameter Header
 #pragma pack(1)
 struct scsiFarmParameterHeader {
-    uint16_t            parameterCode;       // Page Code (0x3D)
-	uint8_t             parameterControl;    // Sub-Page Code (0x03)
-	uint8_t             parameterLength;     // Page Length
+    uint16_t        parameterCode;       // Page Code (0x3D)
+    uint8_t         parameterControl;    // Sub-Page Code (0x03)
+    uint8_t         parameterLength;     // Page Length
 } ATTR_PACKED;
 #pragma pack()
 STATIC_ASSERT(sizeof(scsiFarmParameterHeader) == 4);
@@ -196,16 +196,16 @@ STATIC_ASSERT(sizeof(scsiFarmParameterHeader) == 4);
 // Log Header
 #pragma pack(1)
 struct scsiFarmHeader {
-    scsiFarmParameterHeader parameterHeader;        // Parameter Header
-    uint64_t                signature;              // Log Signature = 0x00004641524D4552
-    uint64_t                majorRev;               // Log Major Revision
-    uint64_t                minorRev;               // Log Rinor Revision
-    uint64_t                parametersSupported;    // Number of Parameters Supported
-    uint64_t                logSize;                // Log Page Size in Bytes
-    uint64_t                reserved;               // Reserved
-    uint64_t                headsSupported;         // Maximum Drive Heads Supported
-    uint64_t                reserved0;              // Reserved
-    uint64_t                frameCapture;           // Reason for Frame Capture
+    scsiFarmParameterHeader     parameterHeader;        // Parameter Header
+    uint64_t                    signature;              // Log Signature = 0x00004641524D4552
+    uint64_t                    majorRev;               // Log Major Revision
+    uint64_t                    minorRev;               // Log Rinor Revision
+    uint64_t                    parametersSupported;    // Number of Parameters Supported
+    uint64_t                    logSize;                // Log Page Size in Bytes
+    uint64_t                    reserved;               // Reserved
+    uint64_t                    headsSupported;         // Maximum Drive Heads Supported
+    uint64_t                    reserved0;              // Reserved
+    uint64_t                    frameCapture;           // Reason for Frame Capture
 } ATTR_PACKED;
 #pragma pack()
 STATIC_ASSERT(sizeof(scsiFarmHeader) == 76);
@@ -214,38 +214,38 @@ STATIC_ASSERT(sizeof(scsiFarmHeader) == 76);
 // Drive Information
 #pragma pack(1)
 struct scsiFarmDriveInformation {
-    scsiFarmParameterHeader parameterHeader;    // Parameter Header
-    uint64_t        pageNumber;                 // Page Number = 1
-    uint64_t        copyNumber;                 // Copy Number
-    uint64_t        serialNumber;               // Serial Number [0:3]
-    uint64_t        serialNumber2;              // Serial Number [4:7]
-    uint64_t        worldWideName;              // World Wide Name [0:3]
-    uint64_t        worldWideName2;             // World Wide Name [4:7]
-    uint64_t        deviceInterface;            // Device Interface
-    uint64_t        deviceCapacity;             // 48-bit Device Capacity
-    uint64_t        psecSize;                   // Physical Sector Size in Bytes
-    uint64_t        lsecSize;                   // Logical Sector Size in Bytes
-    uint64_t        deviceBufferSize;           // Device Buffer Size in Bytes
-    uint64_t        heads;                      // Number of Heads
-    uint64_t        factor;                     // Device Form Factor (ID Word 168)
-    uint64_t        rotationRate;               // Rotational Rate of Device (ID Word 217)
-    uint64_t        firmwareRev;                // Firmware Revision [0:3]
-    uint64_t        firmwareRev2;               // Firmware Revision [4:7]
-    uint64_t        reserved;                   // Reserved
-    uint64_t        reserved0;                  // Reserved
-    uint64_t        reserved1;                  // Reserved
-    uint64_t        poh;                        // Power-On Hours
-    uint64_t        reserved2;                  // Reserved
-    uint64_t        reserved3;                  // Reserved
-    uint64_t        reserved4;                  // Reserved
-    uint64_t        powerCycleCount;            // Power Cycle Count
-    uint64_t        resetCount;                 // Hardware Reset Count
-    uint64_t        reserved5;                  // Reserved
-    uint64_t        reserved6;                  // Reserved
-    uint64_t        reserved7;                  // Reserved
-    uint64_t        reserved8;                  // Reserved
-    uint64_t        reserved9;                  // Reserved
-    uint64_t        dateOfAssembly;             // Date of assembly in ASCII “YYWW” where YY is the year and WW is the calendar week (added 4.2)
+    scsiFarmParameterHeader     parameterHeader;    // Parameter Header
+    uint64_t                    pageNumber;         // Page Number = 1
+    uint64_t                    copyNumber;         // Copy Number
+    uint64_t                    serialNumber;       // Serial Number [0:3]
+    uint64_t                    serialNumber2;      // Serial Number [4:7]
+    uint64_t                    worldWideName;      // World Wide Name [0:3]
+    uint64_t                    worldWideName2;     // World Wide Name [4:7]
+    uint64_t                    deviceInterface;    // Device Interface
+    uint64_t                    deviceCapacity;     // 48-bit Device Capacity
+    uint64_t                    psecSize;           // Physical Sector Size in Bytes
+    uint64_t                    lsecSize;           // Logical Sector Size in Bytes
+    uint64_t                    deviceBufferSize;   // Device Buffer Size in Bytes
+    uint64_t                    heads;              // Number of Heads
+    uint64_t                    factor;             // Device Form Factor (ID Word 168)
+    uint64_t                    rotationRate;       // Rotational Rate of Device (ID Word 217)
+    uint64_t                    firmwareRev;        // Firmware Revision [0:3]
+    uint64_t                    firmwareRev2;       // Firmware Revision [4:7]
+    uint64_t                    reserved;           // Reserved
+    uint64_t                    reserved0;          // Reserved
+    uint64_t                    reserved1;          // Reserved
+    uint64_t                    poh;                // Power-On Hours
+    uint64_t                    reserved2;          // Reserved
+    uint64_t                    reserved3;          // Reserved
+    uint64_t                    reserved4;          // Reserved
+    uint64_t                    powerCycleCount;    // Power Cycle Count
+    uint64_t                    resetCount;         // Hardware Reset Count
+    uint64_t                    reserved5;          // Reserved
+    uint64_t                    reserved6;          // Reserved
+    uint64_t                    reserved7;          // Reserved
+    uint64_t                    reserved8;          // Reserved
+    uint64_t                    reserved9;          // Reserved
+    uint64_t                    dateOfAssembly;     // Date of assembly in ASCII “YYWW” where YY is the year and WW is the calendar week (added 4.2)
 } ATTR_PACKED;
 #pragma pack()
 STATIC_ASSERT(sizeof(scsiFarmDriveInformation) == 252);
@@ -254,25 +254,25 @@ STATIC_ASSERT(sizeof(scsiFarmDriveInformation) == 252);
 // Workload Statistics
 #pragma pack(1)
 struct scsiFarmWorkloadStatistics {
-    scsiFarmParameterHeader parameterHeader;  // Parameter Header
-	uint64_t        pageNumber;               // Page Number = 2
-	uint64_t        copyNumber;               // Copy Number
-	uint64_t        reserved;                 // Reserved
-	uint64_t        totalReadCommands;        // Total Number of Read Commands
-	uint64_t        totalWriteCommands;       // Total Number of Write Commands
-	uint64_t        totalRandomReads;         // Total Number of Random Read Commands
-	uint64_t        totalRandomWrites;        // Total Number of Random Write Commands
-	uint64_t        totalNumberofOtherCMDS;   // Total Number Of Other Commands
-	uint64_t        logicalSecWritten;        // Logical Sectors Written
-	uint64_t        logicalSecRead;           // Logical Sectors Read
-    uint64_t        readCommandsByRadius1;    // Number of Read Commands from 0-3.125% of LBA space for last 3 SMART Summary Frames (added 4.4)
-    uint64_t        readCommandsByRadius2;    // Number of Read Commands from 3.125-25% of LBA space for last 3 SMART Summary Frames (added 4.4)
-    uint64_t        readCommandsByRadius3;    // Number of Read Commands from 25-75% of LBA space for last 3 SMART Summary Frames (added 4.4)
-    uint64_t        readCommandsByRadius4;    // Number of Read Commands from 75-100% of LBA space for last 3 SMART Summary Frames (added 4.4)
-    uint64_t        writeCommandsByRadius1;   // Number of Write Commands from 0-3.125% of LBA space for last 3 SMART Summary Frames (added 4.4)
-    uint64_t        writeCommandsByRadius2;   // Number of Write Commands from 3.125-25% of LBA space for last 3 SMART Summary Frames (added 4.4)
-    uint64_t        writeCommandsByRadius3;   // Number of Write Commands from 25-75% of LBA space for last 3 SMART Summary Frames (added 4.4)
-    uint64_t        writeCommandsByRadius4;   // Number of Write Commands from 75-100% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    scsiFarmParameterHeader     parameterHeader;        // Parameter Header
+    uint64_t                    pageNumber;             // Page Number = 2
+    uint64_t                    copyNumber;             // Copy Number
+    uint64_t                    reserved;               // Reserved
+    uint64_t                    totalReadCommands;      // Total Number of Read Commands
+    uint64_t                    totalWriteCommands;     // Total Number of Write Commands
+    uint64_t                    totalRandomReads;       // Total Number of Random Read Commands
+    uint64_t                    totalRandomWrites;      // Total Number of Random Write Commands
+    uint64_t                    totalNumberofOtherCMDS; // Total Number Of Other Commands
+    uint64_t                    logicalSecWritten;      // Logical Sectors Written
+    uint64_t                    logicalSecRead;         // Logical Sectors Read
+    uint64_t                    readCommandsByRadius1;  // Number of Read Commands from 0-3.125% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    uint64_t                    readCommandsByRadius2;  // Number of Read Commands from 3.125-25% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    uint64_t                    readCommandsByRadius3;  // Number of Read Commands from 25-75% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    uint64_t                    readCommandsByRadius4;  // Number of Read Commands from 75-100% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    uint64_t                    writeCommandsByRadius1; // Number of Write Commands from 0-3.125% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    uint64_t                    writeCommandsByRadius2; // Number of Write Commands from 3.125-25% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    uint64_t                    writeCommandsByRadius3; // Number of Write Commands from 25-75% of LBA space for last 3 SMART Summary Frames (added 4.4)
+    uint64_t                    writeCommandsByRadius4; // Number of Write Commands from 75-100% of LBA space for last 3 SMART Summary Frames (added 4.4)
 } ATTR_PACKED;
 #pragma pack()
 STATIC_ASSERT(sizeof(scsiFarmWorkloadStatistics) == 148);
@@ -281,36 +281,36 @@ STATIC_ASSERT(sizeof(scsiFarmWorkloadStatistics) == 148);
 // Error Statistics
 #pragma pack(1)
 struct scsiFarmErrorStatistics {
-    scsiFarmParameterHeader parameterHeader;        // Parameter Header
-	uint64_t        pageNumber;                     // Page Number = 3
-	uint64_t        copyNumber;                     // Copy Number
-	uint64_t        totalUnrecoverableReadErrors;   // Number of Unrecoverable Read Errors
-	uint64_t        totalUnrecoverableWriteErrors;  // Number of Unrecoverable Write Errors
-	uint64_t        reserved;                       // Reserved
-	uint64_t        reserved0;                      // Reserved
-	uint64_t        totalMechanicalStartRetries;    // Number of Mechanical Start Retries
-	uint64_t        reserved1;                      // Reserved
-	uint64_t        reserved2;                      // Reserved
-	uint64_t        reserved3;                      // Reserved
-	uint64_t        reserved4;                      // Reserved
-	uint64_t        reserved5;                      // Reserved
-	uint64_t        reserved6;                      // Reserved
-	uint64_t        reserved7;                      // Reserved
-	uint64_t        reserved8;                      // Reserved
-	uint64_t        reserved9;                      // Reserved
-	uint64_t        reserved10;                     // Reserved
-	uint64_t        reserved11;                     // Reserved
-	uint64_t        reserved12;                     // Reserved
-	uint64_t        reserved13;                     // Reserved
-    uint64_t        tripCode;                       // If SMART Trip present the reason code (FRU code)
-    uint64_t        invalidDWordCountA;             // Invalid DWord Count (Port A)
-    uint64_t        invalidDWordCountB;             // Invalid DWord Count (Port B)                    
-    uint64_t        disparityErrorCodeA;            // Disparity Error Count (Port A)        
-    uint64_t        disparityErrorCodeB;            // Disparity Error Count (Port A)        
-    uint64_t        lossOfDWordSyncA;               // Loss of DWord Sync (Port A)    
-    uint64_t        lossOfDWordSyncB;               // Loss of DWord Sync (Port A)    
-    uint64_t        phyResetProblemA;               // Phy Reset Problem (Port A)    
-    uint64_t        phyResetProblemB;               // Phy Reset Problem (Port A)    
+    scsiFarmParameterHeader     parameterHeader;                // Parameter Header
+    uint64_t                    pageNumber;                     // Page Number = 3
+    uint64_t                    copyNumber;                     // Copy Number
+    uint64_t                    totalUnrecoverableReadErrors;   // Number of Unrecoverable Read Errors
+    uint64_t                    totalUnrecoverableWriteErrors;  // Number of Unrecoverable Write Errors
+    uint64_t                    reserved;                       // Reserved
+    uint64_t                    reserved0;                      // Reserved
+    uint64_t                    totalMechanicalStartRetries;    // Number of Mechanical Start Retries
+    uint64_t                    reserved1;                      // Reserved
+    uint64_t                    reserved2;                      // Reserved
+    uint64_t                    reserved3;                      // Reserved
+    uint64_t                    reserved4;                      // Reserved
+    uint64_t                    reserved5;                      // Reserved
+    uint64_t                    reserved6;                      // Reserved
+    uint64_t                    reserved7;                      // Reserved
+    uint64_t                    reserved8;                      // Reserved
+    uint64_t                    reserved9;                      // Reserved
+    uint64_t                    reserved10;                     // Reserved
+    uint64_t                    reserved11;                     // Reserved
+    uint64_t                    reserved12;                     // Reserved
+    uint64_t                    reserved13;                     // Reserved
+    uint64_t                    tripCode;                       // If SMART Trip present the reason code (FRU code)
+    uint64_t                    invalidDWordCountA;             // Invalid DWord Count (Port A)
+    uint64_t                    invalidDWordCountB;             // Invalid DWord Count (Port B)                    
+    uint64_t                    disparityErrorCodeA;            // Disparity Error Count (Port A)        
+    uint64_t                    disparityErrorCodeB;            // Disparity Error Count (Port A)        
+    uint64_t                    lossOfDWordSyncA;               // Loss of DWord Sync (Port A)    
+    uint64_t                    lossOfDWordSyncB;               // Loss of DWord Sync (Port A)    
+    uint64_t                    phyResetProblemA;               // Phy Reset Problem (Port A)    
+    uint64_t                    phyResetProblemB;               // Phy Reset Problem (Port A)    
 } ATTR_PACKED;
 #pragma pack()
 STATIC_ASSERT(sizeof(scsiFarmErrorStatistics) == 236);
@@ -319,33 +319,33 @@ STATIC_ASSERT(sizeof(scsiFarmErrorStatistics) == 236);
 // Environment Statistics
 #pragma pack(1)
 struct scsiFarmEnvironmentStatistics {
-    scsiFarmParameterHeader parameterHeader;    // Parameter Header
-	uint64_t         pageNumber;                // Page Number = 4
-	uint64_t         copyNumber;                // Copy Number
-	uint64_t         curentTemp;                // Current Temperature in Celsius (Lower 16 bits are a signed integer in units of 0.1C)
-	uint64_t         highestTemp;               // Highest Temperature in Celsius (Lower 16 bits are a signed integer in units of 0.1C)
-	uint64_t         lowestTemp;                // Lowest Temperature in Celsius (Lower 16 bits are a signed integer in units of 0.1C)  
-	uint64_t         reserved;                  // Reserved
-	uint64_t         reserved0;                 // Reserved
-	uint64_t         reserved1;                 // Reserved
-	uint64_t         reserved2;                 // Reserved
-	uint64_t         reserved3;                 // Reserved
-	uint64_t         reserved4;                 // Reserved
-	uint64_t         reserved5;                 // Reserved
-	uint64_t         reserved6;                 // Reserved
-	uint64_t         maxTemp;                   // Specified Max Operating Temperature in Celsius
-	uint64_t         minTemp;                   // Specified Min Operating Temperature in Celsius
-	uint64_t         reserved7;                 // Reserved
-	uint64_t         reserved8;                 // Reserved
-	uint64_t         humidity;                  // Current Relative Humidity (in units of 0.1%)
-	uint64_t         reserved9;                 // Reserved
-	uint64_t         currentMotorPower;         // Current Motor Power, value from most recent SMART Summary Frame
-    uint64_t         powerAverage12v;           // 12V Power Average (mW) - Average of last 3 SMART Summary Frames (added 4.3)
-    uint64_t         powerMin12v;               // 12V Power Min (mW) - Lowest of last 3 SMART Summary Frames (added 4.3)
-    uint64_t         powerMax12v;               // 12V Power Max (mW) - Highest of last 3 SMART Summary Frames (added 4.3)
-    uint64_t         powerAverage5v;            // 5V Power Average (mW) - Average of last 3 SMART Summary Frames (added 4.3)
-    uint64_t         powerMin5v;                // 5V Power Min (mW) - Lowest of last 3 SMART Summary Frames (added 4.3)
-    uint64_t         powerMax5v;                // 5V Power Max (mW) - Highest of last 3 SMART Summary Frames (added 4.3)
+    scsiFarmParameterHeader     parameterHeader;    // Parameter Header
+    uint64_t                    pageNumber;         // Page Number = 4
+    uint64_t                    copyNumber;         // Copy Number
+    uint64_t                    curentTemp;         // Current Temperature in Celsius (Lower 16 bits are a signed integer in units of 0.1C)
+    uint64_t                    highestTemp;        // Highest Temperature in Celsius (Lower 16 bits are a signed integer in units of 0.1C)
+    uint64_t                    lowestTemp;         // Lowest Temperature in Celsius (Lower 16 bits are a signed integer in units of 0.1C)  
+    uint64_t                    reserved;           // Reserved
+    uint64_t                    reserved0;          // Reserved
+    uint64_t                    reserved1;          // Reserved
+    uint64_t                    reserved2;          // Reserved
+    uint64_t                    reserved3;          // Reserved
+    uint64_t                    reserved4;          // Reserved
+    uint64_t                    reserved5;          // Reserved
+    uint64_t                    reserved6;          // Reserved
+    uint64_t                    maxTemp;            // Specified Max Operating Temperature in Celsius
+    uint64_t                    minTemp;            // Specified Min Operating Temperature in Celsius
+    uint64_t                    reserved7;          // Reserved
+    uint64_t                    reserved8;          // Reserved
+    uint64_t                    humidity;           // Current Relative Humidity (in units of 0.1%)
+    uint64_t                    reserved9;          // Reserved
+    uint64_t                    currentMotorPower;  // Current Motor Power, value from most recent SMART Summary Frame
+    uint64_t                    powerAverage12v;    // 12V Power Average (mW) - Average of last 3 SMART Summary Frames (added 4.3)
+    uint64_t                    powerMin12v;        // 12V Power Min (mW) - Lowest of last 3 SMART Summary Frames (added 4.3)
+    uint64_t                    powerMax12v;        // 12V Power Max (mW) - Highest of last 3 SMART Summary Frames (added 4.3)
+    uint64_t                    powerAverage5v;     // 5V Power Average (mW) - Average of last 3 SMART Summary Frames (added 4.3)
+    uint64_t                    powerMin5v;         // 5V Power Min (mW) - Lowest of last 3 SMART Summary Frames (added 4.3)
+    uint64_t                    powerMax5v;         // 5V Power Max (mW) - Highest of last 3 SMART Summary Frames (added 4.3)
 } ATTR_PACKED;
 #pragma pack()
 STATIC_ASSERT(sizeof(scsiFarmEnvironmentStatistics) == 212);
@@ -354,36 +354,36 @@ STATIC_ASSERT(sizeof(scsiFarmEnvironmentStatistics) == 212);
 // Reliability Statistics
 #pragma pack(1)
 struct scsiFarmReliabilityStatistics {
-    scsiFarmParameterHeader parameterHeader;            // Parameter Header
-	int64_t         pageNumber;                         // Page Number = 5
-	int64_t         copyNumber;                         // Copy Number
-	uint64_t        reserved;                           // Reserved
-	uint64_t        reserved0;                          // Reserved
-	uint64_t        reserved1;                          // Reserved
-	uint64_t        reserved2;                          // Reserved
-	uint64_t        reserved3;                          // Reserved
-	uint64_t        reserved4;                          // Reserved
-	uint64_t        reserved5;                          // Reserved
-	uint64_t        reserved6;                          // Reserved
-	uint64_t        reserved7;                          // Reserved
-	uint64_t        reserved8;                          // Reserved
-	uint64_t        reserved9;                          // Reserved
-	uint64_t        reserved10;                         // Reserved
-	uint64_t        reserved11;                         // Reserved
-	uint64_t        reserved12;                         // Reserved
-	uint64_t        reserved13;                         // Reserved
-	uint64_t        reserved14;                         // Reserved
-    uint64_t        reserved15;                         // Reserved
-	uint64_t        reserved16;                         // Reserved
-	uint64_t        reserved17;                         // Reserved
-	uint64_t        reserved18;                         // Reserved
-	uint64_t        reserved19;                         // Reserved
-    uint64_t        reserved20;                         // Reserved
-    uint64_t        reserved21;                         // Reserved
-	int64_t         heliumPresureTrip;                  // Helium Pressure Threshold Tripped ( 1 - trip, 0 - no trip)
-	uint64_t        reserved34;                         // Reserved
-	uint64_t        reserved35;                         // Reserved
-	uint64_t        reserved36;                         // Reserved
+    scsiFarmParameterHeader     parameterHeader;    // Parameter Header
+    int64_t                     pageNumber;         // Page Number = 5
+    int64_t                     copyNumber;         // Copy Number
+    uint64_t                    reserved;           // Reserved
+    uint64_t                    reserved0;          // Reserved
+    uint64_t                    reserved1;          // Reserved
+    uint64_t                    reserved2;          // Reserved
+    uint64_t                    reserved3;          // Reserved
+    uint64_t                    reserved4;          // Reserved
+    uint64_t                    reserved5;          // Reserved
+    uint64_t                    reserved6;          // Reserved
+    uint64_t                    reserved7;          // Reserved
+    uint64_t                    reserved8;          // Reserved
+    uint64_t                    reserved9;          // Reserved
+    uint64_t                    reserved10;         // Reserved
+    uint64_t                    reserved11;         // Reserved
+    uint64_t                    reserved12;         // Reserved
+    uint64_t                    reserved13;         // Reserved
+    uint64_t                    reserved14;         // Reserved
+    uint64_t                    reserved15;         // Reserved
+    uint64_t                    reserved16;         // Reserved
+    uint64_t                    reserved17;         // Reserved
+    uint64_t                    reserved18;         // Reserved
+    uint64_t                    reserved19;         // Reserved
+    uint64_t                    reserved20;         // Reserved
+    uint64_t                    reserved21;         // Reserved
+    int64_t                     heliumPresureTrip;  // Helium Pressure Threshold Tripped ( 1 - trip, 0 - no trip)
+    uint64_t                    reserved34;         // Reserved
+    uint64_t                    reserved35;         // Reserved
+    uint64_t                    reserved36;         // Reserved
 } ATTR_PACKED;
 #pragma pack()
 STATIC_ASSERT(sizeof(scsiFarmReliabilityStatistics) == 236);
@@ -392,20 +392,20 @@ STATIC_ASSERT(sizeof(scsiFarmReliabilityStatistics) == 236);
 // Drive Information Continued
 #pragma pack(1)
 struct scsiFarmDriveInformation2 {
-    scsiFarmParameterHeader parameterHeader;    // Parameter Header
-    uint64_t        pageNumber;                 // Page Number = 6
-    uint64_t        copyNumber;                 // Copy Number
-    uint64_t        depopulationHeadMask;       // Depopulation Head Mask
-    uint64_t        productID;                  // Product ID [0:3]
-    uint64_t        productID2;                 // Product ID [4:7]
-    uint64_t        productID3;                 // Product ID [8:11]
-    uint64_t        productID4;                 // Product ID [12:15]
-    uint64_t        driveRecordingType;         // Drive Recording Type - 0 for SMR and 1 for CMR
-    uint64_t        dpopped;                    // Is drive currently depopped – 1 = depopped, 0 = not depopped 
-    uint64_t        maxNumberForReasign;        // Max Number of Available Sectors for Re-Assignment – Value in disc sectors 
-    uint64_t        timeToReady;                // Time to Ready of the last power cycle in milliseconds  
-    uint64_t        timeHeld;                   // Time the drive is held in staggered spin in milliseconds 
-    uint64_t        lastServoSpinUpTime;        // The last servo spin up time in milliseconds 
+    scsiFarmParameterHeader     parameterHeader;        // Parameter Header
+    uint64_t                    pageNumber;             // Page Number = 6
+    uint64_t                    copyNumber;             // Copy Number
+    uint64_t                    depopulationHeadMask;   // Depopulation Head Mask
+    uint64_t                    productID;              // Product ID [0:3]
+    uint64_t                    productID2;             // Product ID [4:7]
+    uint64_t                    productID3;             // Product ID [8:11]
+    uint64_t                    productID4;             // Product ID [12:15]
+    uint64_t                    driveRecordingType;     // Drive Recording Type - 0 for SMR and 1 for CMR
+    uint64_t                    dpopped;                // Is drive currently depopped – 1 = depopped, 0 = not depopped 
+    uint64_t                    maxNumberForReasign;    // Max Number of Available Sectors for Re-Assignment – Value in disc sectors 
+    uint64_t                    timeToReady;            // Time to Ready of the last power cycle in milliseconds  
+    uint64_t                    timeHeld;               // Time the drive is held in staggered spin in milliseconds 
+    uint64_t                    lastServoSpinUpTime;    // The last servo spin up time in milliseconds 
 } ATTR_PACKED;
 #pragma pack()
 STATIC_ASSERT(sizeof(scsiFarmDriveInformation2) == 108);
@@ -414,15 +414,15 @@ STATIC_ASSERT(sizeof(scsiFarmDriveInformation2) == 108);
 // Environment Statistics Continued
 #pragma pack(1)
 struct scsiFarmEnvironmentStatistics2 {
-    scsiFarmParameterHeader parameterHeader;    // Parameter Header
-	uint64_t         pageNumber;                // Page Number = 7
-	uint64_t         copyNumber;                // Copy Number
-	uint64_t         current12v;                // Current 12V input in mV
-    uint64_t         min12v;                    // Minimum 12V input from last 3 SMART Summary Frames in mV
-    uint64_t         max12v;                    // Maximum 12V input from last 3 SMART Summary Frames in mV
-    uint64_t         current5v;                 // Current 5V input in mV
-    uint64_t         min5v;                     // Minimum 5V input from last 3 SMART Summary Frames in mV
-    uint64_t         max5v;                     // Maximum 5V input from last 3 SMART Summary Frames in mV
+    scsiFarmParameterHeader     parameterHeader;    // Parameter Header
+    uint64_t                    pageNumber;         // Page Number = 7
+    uint64_t                    copyNumber;         // Copy Number
+    uint64_t                    current12v;         // Current 12V input in mV
+    uint64_t                    min12v;             // Minimum 12V input from last 3 SMART Summary Frames in mV
+    uint64_t                    max12v;             // Maximum 12V input from last 3 SMART Summary Frames in mV
+    uint64_t                    current5v;          // Current 5V input in mV
+    uint64_t                    min5v;              // Minimum 5V input from last 3 SMART Summary Frames in mV
+    uint64_t                    max5v;              // Maximum 5V input from last 3 SMART Summary Frames in mV
 } ATTR_PACKED;
 #pragma pack()
 STATIC_ASSERT(sizeof(scsiFarmEnvironmentStatistics2) == 68);
@@ -431,8 +431,8 @@ STATIC_ASSERT(sizeof(scsiFarmEnvironmentStatistics2) == 68);
 // "By Head" Parameters
 #pragma pack(1)
 struct scsiFarmByHead {
-    scsiFarmParameterHeader parameterHeader;    // Parameter Header
-	uint64_t                headValue[16];      // [16] Head Information
+    scsiFarmParameterHeader     parameterHeader;    // Parameter Header
+    uint64_t                    headValue[16];      // [16] Head Information
 } ATTR_PACKED;
 #pragma pack()
 STATIC_ASSERT(sizeof(scsiFarmByHead) == (4 + (16 * 8)));
@@ -441,30 +441,30 @@ STATIC_ASSERT(sizeof(scsiFarmByHead) == (4 + (16 * 8)));
 // "By Actuator" Parameters
 #pragma pack(1)
 struct scsiFarmByActuator {
-    scsiFarmParameterHeader parameterHeader;                        // Parameter Header
-	uint64_t                pageNumber;                             // Page Number
-	uint64_t                copyNumber;                             // Copy Number  
-    uint64_t                actuatorID;                             // Actuator ID 
-    uint64_t                headLoadEvents;                         // Head Load Events 
-    uint64_t                reserved;                               // Reserved 
-    uint64_t                reserved0;                              // Reserved 
-    uint64_t                timelastIDDTest;                        // Timestamp of last IDD test 
-    uint64_t                subcommandlastIDDTest;                  // Sub-Command of last IDD test 
-    uint64_t                numberGListReclam;                      // Number of G-list reclamations 
-    uint64_t                servoStatus;                            // Servo Status (follows standard DST error code definitions) 
-    uint64_t                numberSlippedSectorsBeforeIDD;          // Number of Slipped Sectors Before IDD Scan 
-    uint64_t                numberSlippedSectorsAfterIDD;           // Number of Slipped Sectors After IDD Scan 
-    uint64_t                numberResidentReallocatedBeforeIDD;     // Number of Resident Reallocated Sectors Before IDD Scan 
-    uint64_t                numberResidentReallocatedAfterIDD;      // Number of Resident Reallocated Sectors After IDD Scan 
-    uint64_t                numberScrubbedSectorsBeforeIDD;         // Number of Successfully Scrubbed Sectors Before IDD Scan 
-    uint64_t                numberScrubbedSectorsAfterIDD;          // Number of Successfully Scrubbed Sectors After IDD Scan 
-    uint64_t                dosScansPerformed;                      // Number of DOS Scans Performed 
-    uint64_t                lbasCorrectedISP;                       // Number of LBAs Corrected by ISP 
-    uint64_t                numberValidParitySectors;               // Number of Valid Parity Sectors 
-    uint64_t                reserved1;                              // Reserved 
-    uint64_t                reserved2;                              // Reserved 
-    uint64_t                reserved3;                              // Reserved 
-    uint64_t                numberLBACorrectedParitySector;         // Number of LBAs Corrected by Parity Sector 
+    scsiFarmParameterHeader     parameterHeader;                    // Parameter Header
+    uint64_t                    pageNumber;                         // Page Number
+    uint64_t                    copyNumber;                         // Copy Number  
+    uint64_t                    actuatorID;                         // Actuator ID 
+    uint64_t                    headLoadEvents;                     // Head Load Events 
+    uint64_t                    reserved;                           // Reserved 
+    uint64_t                    reserved0;                          // Reserved 
+    uint64_t                    timelastIDDTest;                    // Timestamp of last IDD test 
+    uint64_t                    subcommandlastIDDTest;              // Sub-Command of last IDD test 
+    uint64_t                    numberGListReclam;                  // Number of G-list reclamations 
+    uint64_t                    servoStatus;                        // Servo Status (follows standard DST error code definitions) 
+    uint64_t                    numberSlippedSectorsBeforeIDD;      // Number of Slipped Sectors Before IDD Scan 
+    uint64_t                    numberSlippedSectorsAfterIDD;       // Number of Slipped Sectors After IDD Scan 
+    uint64_t                    numberResidentReallocatedBeforeIDD; // Number of Resident Reallocated Sectors Before IDD Scan 
+    uint64_t                    numberResidentReallocatedAfterIDD;  // Number of Resident Reallocated Sectors After IDD Scan 
+    uint64_t                    numberScrubbedSectorsBeforeIDD;     // Number of Successfully Scrubbed Sectors Before IDD Scan 
+    uint64_t                    numberScrubbedSectorsAfterIDD;      // Number of Successfully Scrubbed Sectors After IDD Scan 
+    uint64_t                    dosScansPerformed;                  // Number of DOS Scans Performed 
+    uint64_t                    lbasCorrectedISP;                   // Number of LBAs Corrected by Intermediate Super Parity 
+    uint64_t                    numberValidParitySectors;           // Number of Valid Parity Sectors 
+    uint64_t                    reserved1;                          // Reserved 
+    uint64_t                    reserved2;                          // Reserved 
+    uint64_t                    reserved3;                          // Reserved 
+    uint64_t                    numberLBACorrectedParitySector;     // Number of LBAs Corrected by Parity Sector 
 } ATTR_PACKED;
 #pragma pack()
 STATIC_ASSERT(sizeof(scsiFarmByActuator) == (188));
@@ -473,15 +473,15 @@ STATIC_ASSERT(sizeof(scsiFarmByActuator) == (188));
 // "By Actuator" Parameters for Flash LED Information
 #pragma pack(1)
 struct scsiFarmByActuatorFLED {
-    scsiFarmParameterHeader parameterHeader;                        // Parameter Header
-	uint64_t                pageNumber;                             // Page Number
-	uint64_t                copyNumber;                             // Copy Number  
-    uint64_t                actuatorID;                             // Actuator ID 
-    uint64_t                totalFlashLED;                          // Total Flash LED (Assert) Events
-    uint64_t                indexFlashLED;                          // Index of last entry in Flash LED Info array below, in case the array wraps
-    uint64_t                flashLEDArray[8];                       // Info on the last 8 Flash LED (assert) events wrapping array
-    uint64_t                universalTimestampFlashLED[8];          // Universal Timestamp (us) of last 8 Flash LED (assert) Events, wrapping array
-    uint64_t                powerCycleFlashLED[8];                  // Power Cycle of the last 8 Flash LED (assert) Events, wrapping array
+    scsiFarmParameterHeader     parameterHeader;                // Parameter Header
+    uint64_t                    pageNumber;                     // Page Number
+    uint64_t                    copyNumber;                     // Copy Number  
+    uint64_t                    actuatorID;                     // Actuator ID 
+    uint64_t                    totalFlashLED;                  // Total Flash LED (Assert) Events
+    uint64_t                    indexFlashLED;                  // Index of last entry in Flash LED Info array below, in case the array wraps
+    uint64_t                    flashLEDArray[8];               // Info on the last 8 Flash LED (assert) events wrapping array
+    uint64_t                    universalTimestampFlashLED[8];  // Universal Timestamp (us) of last 8 Flash LED (assert) Events, wrapping array
+    uint64_t                    powerCycleFlashLED[8];          // Power Cycle of the last 8 Flash LED (assert) Events, wrapping array
 } ATTR_PACKED;
 #pragma pack()
 STATIC_ASSERT(sizeof(scsiFarmByActuatorFLED) == (236));
@@ -490,13 +490,13 @@ STATIC_ASSERT(sizeof(scsiFarmByActuatorFLED) == (236));
 // "By Actuator" Parameters for Reallocation Information
 #pragma pack(1)
 struct scsiFarmByActuatorReallocation {
-    scsiFarmParameterHeader parameterHeader;                        // Parameter Header
-	uint64_t                pageNumber;                             // Page Number
-	uint64_t                copyNumber;                             // Copy Number  
-    uint64_t                actuatorID;                             // Actuator ID 
-    uint64_t                totalReallocations;                     // Number of Re-Allocated Sectors
-    uint64_t                totalReallocationCanidates;             // Number of Re-Allocated Candidate Sectors 
-    uint64_t                reserved[15];                           // Reserved
+    scsiFarmParameterHeader     parameterHeader;            // Parameter Header
+    uint64_t                    pageNumber;                 // Page Number
+    uint64_t                    copyNumber;                 // Copy Number  
+    uint64_t                    actuatorID;                 // Actuator ID 
+    uint64_t                    totalReallocations;         // Number of Re-Allocated Sectors
+    uint64_t                    totalReallocationCanidates; // Number of Re-Allocated Candidate Sectors 
+    uint64_t                    reserved[15];               // Reserved
 } ATTR_PACKED;
 #pragma pack()
 STATIC_ASSERT(sizeof(scsiFarmByActuatorReallocation) == (164));
@@ -504,74 +504,74 @@ STATIC_ASSERT(sizeof(scsiFarmByActuatorReallocation) == (164));
 // Seagate Field Access Reliability Metrics log (FARM) all parameters
 #pragma pack(1)
 struct scsiFarmLog {
-    scsiFarmPageHeader                      pageHeader;                             // Head for whole log page
-    scsiFarmHeader                          header;                                 // Log Header parameter
-	scsiFarmDriveInformation                driveInformation;                       // Drive Information parameter
-	scsiFarmWorkloadStatistics              workload;                               // Workload Statistics parameter
-	scsiFarmErrorStatistics                 error;                                  // Error Statistics parameter
-	scsiFarmEnvironmentStatistics           environment;                            // Environment Statistics parameter 
-	scsiFarmReliabilityStatistics           reliability;                            // Reliability Statistics parameter
-    scsiFarmDriveInformation2               driveInformation2;                      // Drive Information parameter continued
-    scsiFarmEnvironmentStatistics2          environment2;                           // Environment Statistics parameter continued
-    scsiFarmByHead                          reserved;                               // Reserved
-    scsiFarmByHead                          reserved0;                              // Reserved
-    scsiFarmByHead                          reserved1;                              // Reserved
-    scsiFarmByHead                          reserved2;                              // Reserved
-    scsiFarmByHead                          reserved3;                              // Reserved
-    scsiFarmByHead                          reserved4;                              // Reserved
-    scsiFarmByHead                          reserved5;                              // Reserved
-    scsiFarmByHead                          reserved6;                              // Reserved
-    scsiFarmByHead                          reserved7;                              // Reserved
-    scsiFarmByHead                          reserved8;                              // Reserved
-    scsiFarmByHead                          mrHeadResistance;                       // MR Head Resistance from most recent SMART Summary Frame by Head
-    scsiFarmByHead                          reserved9;                              // Reserved
-    scsiFarmByHead                          reserved10;                             // Reserved
-    scsiFarmByHead                          reserved11;                             // Reserved
-    scsiFarmByHead                          reserved12;                             // Reserved
-    scsiFarmByHead                          reserved13;                             // Reserved
-    scsiFarmByHead                          reserved14;                             // Reserved
-    scsiFarmByHead                          totalReallocations;                     // Number of Reallocated Sectors
-    scsiFarmByHead                          totalReallocationCanidates;             // Number of Reallocation Candidate Sectors
-    scsiFarmByHead                          reserved15;                             // Reserved
-    scsiFarmByHead                          reserved16;                             // Reserved
-    scsiFarmByHead                          reserved17;                             // Reserved
-    scsiFarmByHead                          writeWorkloadPowerOnTime;               // Write Workload Power-on Time in Seconds, value from most recent SMART Frame by Head
-    scsiFarmByHead                          reserved18;                             // Reserved
-    scsiFarmByHead                          cumulativeUnrecoverableReadRepeat;      // Cumulative Lifetime Unrecoverable Read Repeat by head
-    scsiFarmByHead                          cumulativeUnrecoverableReadUnique;      // Cumulative Lifetime Unrecoverable Read Unique by head
-    scsiFarmByHead                          reserved19;                             // Reserved
-    scsiFarmByHead                          reserved20;                             // Reserved
-    scsiFarmByHead                          reserved21;                             // Reserved
-    scsiFarmByHead                          reserved22;                             // Reserved
-    scsiFarmByHead                          reserved23;                             // Reserved
-    scsiFarmByHead                          reserved24;                             // Reserved
-    scsiFarmByHead                          reserved25;                             // Reserved
-    scsiFarmByHead                          reserved26;                             // Reserved
-    scsiFarmByHead                          reserved27;                             // Reserved
-    scsiFarmByHead                          secondMRHeadResistance;                 // Second Head MR Head Resistance from most recent SMART Summary Frame by Head
-    scsiFarmByHead                          reserved28;                             // Reserved
-    scsiFarmByHead                          reserved29;                             // Reserved
-    scsiFarmByHead                          reserved30;                             // Reserved
-    scsiFarmByHead                          reserved31;                             // Reserved
-    scsiFarmByHead                          reserved32;                             // Reserved
-    scsiFarmByHead                          reserved33;                             // Reserved
-    scsiFarmByHead                          reserved34;                             // Reserved
-    scsiFarmByHead                          reserved35;                             // Reserved
-    scsiFarmByHead                          reserved36;                             // Reserved
-    scsiFarmByHead                          reserved37;                             // Reserved
-    scsiFarmByHead                          reserved38;                             // Reserved
-    scsiFarmByActuator                      actuator0;                              // Actuator 0 parameters
-    scsiFarmByActuatorFLED                  actuatorFLED0;                          // Actuator 0 FLED Information parameters
-    scsiFarmByActuatorReallocation          actuatorReallocation0;                  // Actuator 0 Reallocation parameters
-    scsiFarmByActuator                      actuator1;                              // Actuator 1 parameters
-    scsiFarmByActuatorFLED                  actuatorFLED1;                          // Actuator 1 FLED Information parameters
-    scsiFarmByActuatorReallocation          actuatorReallocation1;                  // Actuator 1 Reallocation parameters
-    scsiFarmByActuator                      actuator2;                              // Actuator 2 parameters
-    scsiFarmByActuatorFLED                  actuatorFLED2;                          // Actuator 2 FLED Information parameters
-    scsiFarmByActuatorReallocation          actuatorReallocation2;                  // Actuator 2 Reallocation parameters
-    scsiFarmByActuator                      actuator3;                              // Actuator 3 parameters
-    scsiFarmByActuatorFLED                  actuatorFLED3;                          // Actuator 3 FLED Information parameters
-    scsiFarmByActuatorReallocation          actuatorReallocation3;                  // Actuator 3 Reallocation parameters
+    scsiFarmPageHeader                  pageHeader;                         // Head for whole log page
+    scsiFarmHeader                      header;                             // Log Header parameter
+    scsiFarmDriveInformation            driveInformation;                   // Drive Information parameter
+    scsiFarmWorkloadStatistics          workload;                           // Workload Statistics parameter
+    scsiFarmErrorStatistics             error;                              // Error Statistics parameter
+    scsiFarmEnvironmentStatistics       environment;                        // Environment Statistics parameter 
+    scsiFarmReliabilityStatistics       reliability;                        // Reliability Statistics parameter
+    scsiFarmDriveInformation2           driveInformation2;                  // Drive Information parameter continued
+    scsiFarmEnvironmentStatistics2      environment2;                       // Environment Statistics parameter continued
+    scsiFarmByHead                      reserved;                           // Reserved
+    scsiFarmByHead                      reserved0;                          // Reserved
+    scsiFarmByHead                      reserved1;                          // Reserved
+    scsiFarmByHead                      reserved2;                          // Reserved
+    scsiFarmByHead                      reserved3;                          // Reserved
+    scsiFarmByHead                      reserved4;                          // Reserved
+    scsiFarmByHead                      reserved5;                          // Reserved
+    scsiFarmByHead                      reserved6;                          // Reserved
+    scsiFarmByHead                      reserved7;                          // Reserved
+    scsiFarmByHead                      reserved8;                          // Reserved
+    scsiFarmByHead                      mrHeadResistance;                   // MR Head Resistance from most recent SMART Summary Frame by Head
+    scsiFarmByHead                      reserved9;                          // Reserved
+    scsiFarmByHead                      reserved10;                         // Reserved
+    scsiFarmByHead                      reserved11;                         // Reserved
+    scsiFarmByHead                      reserved12;                         // Reserved
+    scsiFarmByHead                      reserved13;                         // Reserved
+    scsiFarmByHead                      reserved14;                         // Reserved
+    scsiFarmByHead                      totalReallocations;                 // Number of Reallocated Sectors
+    scsiFarmByHead                      totalReallocationCanidates;         // Number of Reallocation Candidate Sectors
+    scsiFarmByHead                      reserved15;                         // Reserved
+    scsiFarmByHead                      reserved16;                         // Reserved
+    scsiFarmByHead                      reserved17;                         // Reserved
+    scsiFarmByHead                      writeWorkloadPowerOnTime;           // Write Workload Power-on Time in Seconds, value from most recent SMART Frame by Head
+    scsiFarmByHead                      reserved18;                         // Reserved
+    scsiFarmByHead                      cumulativeUnrecoverableReadRepeat;  // Cumulative Lifetime Unrecoverable Read Repeat by head
+    scsiFarmByHead                      cumulativeUnrecoverableReadUnique;  // Cumulative Lifetime Unrecoverable Read Unique by head
+    scsiFarmByHead                      reserved19;                         // Reserved
+    scsiFarmByHead                      reserved20;                         // Reserved
+    scsiFarmByHead                      reserved21;                         // Reserved
+    scsiFarmByHead                      reserved22;                         // Reserved
+    scsiFarmByHead                      reserved23;                         // Reserved
+    scsiFarmByHead                      reserved24;                         // Reserved
+    scsiFarmByHead                      reserved25;                         // Reserved
+    scsiFarmByHead                      reserved26;                         // Reserved
+    scsiFarmByHead                      reserved27;                         // Reserved
+    scsiFarmByHead                      secondMRHeadResistance;             // Second Head MR Head Resistance from most recent SMART Summary Frame by Head
+    scsiFarmByHead                      reserved28;                         // Reserved
+    scsiFarmByHead                      reserved29;                         // Reserved
+    scsiFarmByHead                      reserved30;                         // Reserved
+    scsiFarmByHead                      reserved31;                         // Reserved
+    scsiFarmByHead                      reserved32;                         // Reserved
+    scsiFarmByHead                      reserved33;                         // Reserved
+    scsiFarmByHead                      reserved34;                         // Reserved
+    scsiFarmByHead                      reserved35;                         // Reserved
+    scsiFarmByHead                      reserved36;                         // Reserved
+    scsiFarmByHead                      reserved37;                         // Reserved
+    scsiFarmByHead                      reserved38;                         // Reserved
+    scsiFarmByActuator                  actuator0;                          // Actuator 0 parameters
+    scsiFarmByActuatorFLED              actuatorFLED0;                      // Actuator 0 FLED Information parameters
+    scsiFarmByActuatorReallocation      actuatorReallocation0;              // Actuator 0 Reallocation parameters
+    scsiFarmByActuator                  actuator1;                          // Actuator 1 parameters
+    scsiFarmByActuatorFLED              actuatorFLED1;                      // Actuator 1 FLED Information parameters
+    scsiFarmByActuatorReallocation      actuatorReallocation1;              // Actuator 1 Reallocation parameters
+    scsiFarmByActuator                  actuator2;                          // Actuator 2 parameters
+    scsiFarmByActuatorFLED              actuatorFLED2;                      // Actuator 2 FLED Information parameters
+    scsiFarmByActuatorReallocation      actuatorReallocation2;              // Actuator 2 Reallocation parameters
+    scsiFarmByActuator                  actuator3;                          // Actuator 3 parameters
+    scsiFarmByActuatorFLED              actuatorFLED3;                      // Actuator 3 FLED Information parameters
+    scsiFarmByActuatorReallocation      actuatorReallocation3;              // Actuator 3 Reallocation parameters
 } ATTR_PACKED;
 #pragma pack()
 STATIC_ASSERT(sizeof(scsiFarmLog) == 4 + 76 + 252 + 148 + 236 + 212 + 236 + 108 + 68 + (47 * ((8 * 16) + 4)) + 188 * 4 + 236 * 4 + 164 * 4);

--- a/smartmontools/scsiprint.cpp
+++ b/smartmontools/scsiprint.cpp
@@ -2800,16 +2800,22 @@ scsiPrintMain(scsi_device * device, const scsi_print_options & options)
         if (gSeagateFarmLPage) {
             scsiFarmLog * ptr_farmLog = scsiReadFarmLog(device);
             if (ptr_farmLog == NULL) {
-                pout("Read FARM log (SCSI log page 0x3D, sub-page 0x3) failed\n\n");
+                if (!options.all) {
+                    pout("Read FARM log (SCSI log page 0x3D, sub-page 0x3) failed\n\n");
+                }
             } else {
                 if (!scsiPrintFarmLog(ptr_farmLog)) {
-                    pout("Print FARM log (SCSI log page 0x3D, sub-page 0x3) failed\n\n");
+                    if (!options.all) {
+                        pout("Print FARM log (SCSI log page 0x3D, sub-page 0x3) failed\n\n");
+                    }
                 }
             }
             delete ptr_farmLog;
             ptr_farmLog = NULL;
         } else {
-            pout("FARM log (SCSI log page 0x3D, sub-page 0x3) not supported\n\n");
+            if (!options.all) {
+                pout("FARM log (SCSI log page 0x3D, sub-page 0x3) not supported\n\n");
+            }
         }
     }
     if (options.smart_error_log) {

--- a/smartmontools/scsiprint.cpp
+++ b/smartmontools/scsiprint.cpp
@@ -2801,12 +2801,16 @@ scsiPrintMain(scsi_device * device, const scsi_print_options & options)
             scsiFarmLog * ptr_farmLog = scsiReadFarmLog(device);
             if (ptr_farmLog == NULL) {
                 if (!options.all) {
-                    pout("Read FARM log (SCSI log page 0x3D, sub-page 0x3) failed\n\n");
+                    jout("\nRead FARM log (SCSI log page 0x3D, sub-page 0x3) failed\n\n");
+                    json::ref js = jglb["seagate_farm_log_supported"];
+                    js = false;
                 }
             } else {
                 if (!scsiPrintFarmLog(ptr_farmLog)) {
                     if (!options.all) {
-                        pout("Print FARM log (SCSI log page 0x3D, sub-page 0x3) failed\n\n");
+                        jout("\nPrint FARM log (SCSI log page 0x3D, sub-page 0x3) failed\n\n");
+                        json::ref js = jglb["seagate_farm_log_supported"];
+                        js = false;
                     }
                 }
             }
@@ -2814,7 +2818,9 @@ scsiPrintMain(scsi_device * device, const scsi_print_options & options)
             ptr_farmLog = NULL;
         } else {
             if (!options.all) {
-                pout("FARM log (SCSI log page 0x3D, sub-page 0x3) not supported\n\n");
+                jout("\nFARM log (SCSI log page 0x3D, sub-page 0x3) not supported\n\n");
+                json::ref js = jglb["seagate_farm_log_supported"];
+                js = false;
             }
         }
     }

--- a/smartmontools/scsiprint.cpp
+++ b/smartmontools/scsiprint.cpp
@@ -858,8 +858,8 @@ scsiPrintSeagateFactoryLPage(scsi_device * device)
  */
 static scsiFarmLog * scsiReadFarmLog(scsi_device * device) {
     const size_t FARM_ATTRIBUTE_SIZE = 8;
-    scsiFarmLog farmLog;
-    scsiFarmLog * ptr_farmLog = &farmLog;
+    scsiFarmLog * ptr_farmLog = new scsiFarmLog;
+    memset(ptr_farmLog, 0, sizeof(scsiFarmLog));
     if (0 != scsiLogSense(device, SEAGATE_FARM_LPAGE, SEAGATE_FARM_CURRENT_L_SPAGE, gBuf, LOG_RESP_LONG_LEN, 0)) {
         jerr("Read FARM Log page failed\n\n");
         return NULL;
@@ -2806,6 +2806,8 @@ scsiPrintMain(scsi_device * device, const scsi_print_options & options)
                     pout("Print FARM log (SCSI log page 0x3D, sub-page 0x3) failed\n\n");
                 }
             }
+            delete ptr_farmLog;
+            ptr_farmLog = NULL;
         } else {
             pout("FARM log (SCSI log page 0x3D, sub-page 0x3) not supported\n\n");
         }

--- a/smartmontools/scsiprint.cpp
+++ b/smartmontools/scsiprint.cpp
@@ -849,6 +849,23 @@ scsiPrintSeagateFactoryLPage(scsi_device * device)
 // Seagate Field Access Reliability Metrics (FARM) log (Log page 0x3D, sub-page 0x3)
 
 /*
+ *  Simple max element function helper for printing Seagate FARM Logs
+ *  
+ *  @param  arr:    Array with metric values (uint64_t [])
+ *  @param  n:      Size of array (size_t)    
+ *  @return Maximum value of given array (uint64_t)
+ */
+static uint64_t getMaxValFARM(uint64_t arr[], size_t n) {
+  uint64_t currentMax = 0;
+  for (unsigned i = 0; i < n; i++) {
+    if (arr[i] > currentMax) {
+        currentMax = arr[i];
+    }
+  }
+  return currentMax;
+}
+
+/*
  *  Reads vendor-specific FARM log (SCSI log page 0x3D, sub-page 0x3) data from Seagate
  *  drives and parses data into FARM log structures
  *  Returns parsed structure as defined in scsicmds.h
@@ -1014,32 +1031,152 @@ static bool scsiPrintFarmLog(scsiFarmLog * ptr_farmLog) {
         jerr("Error printing parsed FARM log data\n\n");
         return false;
     }
+    size_t n = ptr_farmLog->driveInformation.heads;
     // Print plain-text
     jout("\nSeagate Field Access Reliability Metrics log (FARM) (SCSI Log page 0x3D, sub-page 0x3)\n");
-    jout("FARM Log Major Revision: %lu\n", ptr_farmLog->header.majorRev);
-    jout("FARM Log Minor Revision: %lu\n", ptr_farmLog->header.minorRev);
-    jout("Number of Unrecoverable Read Errors: %lu\n", ptr_farmLog->error.totalUnrecoverableReadErrors);
-    jout("Number of Unrecoverable Write Errors: %lu\n",ptr_farmLog->error.totalUnrecoverableWriteErrors);
-    jout("Number of Mechanical Start Failures: %lu\n", ptr_farmLog->error.totalMechanicalStartRetries);
-    jout("Current 12V Input (mV): %lu\n", ptr_farmLog->environment2.current12v);
-    jout("Minimum 12V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environment2.min12v);
-    jout("Maximum 12V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environment2.max12v);
-    jout("Current 5V Input (mV): %lu\n", ptr_farmLog->environment2.current5v);
-    jout("Minimum 5V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environment2.min5v);
-    jout("Maximum 5V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environment2.max5v);
+    // Parameter 0: Log Header
+    jout("\tFARM Log Parameter 0: Log Header\n");
+    jout("\t\tFARM Log Version: %lu.%lu\n", ptr_farmLog->header.majorRev, ptr_farmLog->header.minorRev);
+    // Parameter 1: Drive Information
+    jout("\tFARM Log Parameter 1: Drive Information\n");
+    jout("\n");
+    // Parameter 2/6: Workload Statistics
+    jout("\tFARM Log Parameter 2/6: Workload Statistics\n");
+    jout("\n");
+    // Parameter 3: Error Statistics
+    jout("\tFARM Log Parameter 3: Error Statistics\n");
+    jout("\t\tNumber of Unrecoverable Read Errors: %lu\n", ptr_farmLog->error.totalUnrecoverableReadErrors);
+    jout("\t\tNumber of Unrecoverable Write Errors: %lu\n",ptr_farmLog->error.totalUnrecoverableWriteErrors);
+    jout("\t\tNumber of Mechanical Start Failures: %lu\n", ptr_farmLog->error.totalMechanicalStartRetries);
+    // Parameter 4/7: Environment Statistics
+    jout("\tFARM Log Parameter 4/7: Environment Statistics\n");
+    jout("\t\tCurrent 12V Input (mV): %lu\n", ptr_farmLog->environment2.current12v);
+    jout("\t\tMinimum 12V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environment2.min12v);
+    jout("\t\tMaximum 12V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environment2.max12v);
+    jout("\t\tCurrent 5V Input (mV): %lu\n", ptr_farmLog->environment2.current5v);
+    jout("\t\tMinimum 5V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environment2.min5v);
+    jout("\t\tMaximum 5V input from last 3 SMART Summary Frames (mV): %lu\n", ptr_farmLog->environment2.max5v);
+    jout("\t\t12V Power Average (mW): %lu\n", ptr_farmLog->environment.powerAverage12v);
+    // Parameter 5: Reliability Statistics
+    jout("\tFARM Log Parameter 5: Reliability Statistics\n");
+    jout("\n");
+    // "By Actuator" Parameters
+    jout("\tFARM Log \"By Actuator\" Parameters\n");
+    jout("\t\tHead Load Events:\n");
+    jout("\t\t\tActuator 0: %lu\n", ptr_farmLog->actuator0.headLoadEvents);
+    jout("\t\t\tActuator 1: %lu\n", ptr_farmLog->actuator1.headLoadEvents);
+    jout("\t\t\tActuator 2: %lu\n", ptr_farmLog->actuator2.headLoadEvents);
+    jout("\t\t\tActuator 3: %lu\n", ptr_farmLog->actuator3.headLoadEvents);
+    jout("\t\tLBAs Corrected By Intermediate Super Parity:\n");
+    jout("\t\t\tActuator 0: %lu\n", ptr_farmLog->actuator0.lbasCorrectedISP);
+    jout("\t\t\tActuator 1: %lu\n", ptr_farmLog->actuator1.lbasCorrectedISP);
+    jout("\t\t\tActuator 2: %lu\n", ptr_farmLog->actuator2.lbasCorrectedISP);
+    jout("\t\t\tActuator 3: %lu\n", ptr_farmLog->actuator3.lbasCorrectedISP);
+    jout("\t\tLBAs Corrected By Parity Sector:\n");
+    jout("\t\t\tActuator 0: %lu\n", ptr_farmLog->actuator0.numberLBACorrectedParitySector);
+    jout("\t\t\tActuator 1: %lu\n", ptr_farmLog->actuator1.numberLBACorrectedParitySector);
+    jout("\t\t\tActuator 2: %lu\n", ptr_farmLog->actuator2.numberLBACorrectedParitySector);
+    jout("\t\t\tActuator 3: %lu\n", ptr_farmLog->actuator3.numberLBACorrectedParitySector);
+    // "By Head" Parameters
+    jout("\tFARM Log \"By Head\" Parameters\n");
+    jout("\t\tNumber of Reallocated Sectors:\n");
+    for (unsigned i = 0; i < n; i++) {
+        jout("\t\t\tHead %i: %lu\n", i, ptr_farmLog->totalReallocations.headValue[i]);
+    }
+    jout("\t\tNumber of Reallocated Candidate Sectors:\n");
+    for (unsigned i = 0; i < n; i++) {
+        jout("\t\t\tHead %i: %lu\n", i, ptr_farmLog->totalReallocationCanidates.headValue[i]);
+    }
+    // Private metrics
+    jout("\tFARM Log: Private Metrics\n");
+    jout("\t\tPrivate Metric 5-188: %lu\n", ptr_farmLog->reliability.reserved20);
+    jout("\t\tPrivate Metric 5-196: %lu\n", ptr_farmLog->reliability.reserved21);
+    jout("\t\tPrivate Metric 18-All: %lu\n", getMaxValFARM(ptr_farmLog->reserved1.headValue, n));
+    jout("\t\tPrivate Metric 29-All: %lu\n", getMaxValFARM(ptr_farmLog->reserved11.headValue, n));
+    jout("\t\tPrivate Metric 30-All: %lu\n", getMaxValFARM(ptr_farmLog->reserved12.headValue, n));
+    jout("\t\tPrivate Metric 48-All: %0.01f\n", (double) getMaxValFARM(ptr_farmLog->reserved19.headValue, n) * 0.1);
+    jout("\t\tPrivate Metric 49-All: %0.01f\n", (double) getMaxValFARM(ptr_farmLog->reserved20.headValue, n) * 0.1);
+    jout("\t\tPrivate Metric 50-All: %0.01f\n", (double) getMaxValFARM(ptr_farmLog->reserved21.headValue, n) * 0.1);
+    jout("\t\tPrivate Metric 51-All: %0.01f\n", (double) getMaxValFARM(ptr_farmLog->reserved22.headValue, n) * 0.1);
+    jout("\t\tPrivate Metric 52-All: %0.01f\n", (double) getMaxValFARM(ptr_farmLog->reserved23.headValue, n) * 0.1);
+    jout("\t\tPrivate Metric 53-All: %0.01f\n", (double) getMaxValFARM(ptr_farmLog->reserved24.headValue, n) * 0.1);
     // Print JSON if --json or -j is specified
+    char str[50];
     json::ref jref = jglb["seagate_farm_log"];
-    jref["log_major_revision"] = ptr_farmLog->header.majorRev;
-    jref["log_minor_revision"] = ptr_farmLog->header.minorRev;
-    jref["number_of_unrecoverable_read_errors"] = ptr_farmLog->error.totalUnrecoverableReadErrors;
-    jref["number_of_unrecoverable_write_errors"] = ptr_farmLog->error.totalUnrecoverableWriteErrors;
-    jref["number_of_mechanical_start_failures"] = ptr_farmLog->error.totalMechanicalStartRetries;
-    jref["current_12_volt_input_in_mv"] = ptr_farmLog->environment2.current12v;
-    jref["minimum_12_volt_input_in_mv"] = ptr_farmLog->environment2.min12v;
-    jref["maximum_12_volt_input_in_mv"] = ptr_farmLog->environment2.max12v;
-    jref["current_5_volt_input_in_mv"] = ptr_farmLog->environment2.current5v;
-    jref["minimum_5_volt_input_in_mv"] = ptr_farmLog->environment2.min5v;
-    jref["maximum_5_volt_input_in_mv"] = ptr_farmLog->environment2.max5v;
+    // Parameter 0: Log Header
+    json::ref jref0 = jref["parameter_0_log_header"];
+    sprintf(str, "%lu.%lu", ptr_farmLog->header.majorRev, ptr_farmLog->header.minorRev);
+    jref0["farm_log_version"] = str;
+    // Parameter 1: Drive Information
+    json::ref jref1 = jref["parameter_1_drive_information"];
+    // Parameter 2/6: Workload Statistics
+    json::ref jref2 = jref["parameter_2_or_6_workload_statistics"];
+    // Parameter 3: Error Statistics
+    json::ref jref3 = jref["parameter_3_error_statistics"];
+    jref3["number_of_unrecoverable_read_errors"] = ptr_farmLog->error.totalUnrecoverableReadErrors;
+    jref3["number_of_unrecoverable_write_errors"] = ptr_farmLog->error.totalUnrecoverableWriteErrors;
+    jref3["number_of_mechanical_start_failures"] = ptr_farmLog->error.totalMechanicalStartRetries;
+    // Parameter 4/7: Environment Statistics
+    json::ref jref4 = jref["parameter_4_or_7_environment_statistics"];
+    jref4["current_12_volt_input_in_mv"] = ptr_farmLog->environment2.current12v;
+    jref4["minimum_12_volt_input_in_mv"] = ptr_farmLog->environment2.min12v;
+    jref4["maximum_12_volt_input_in_mv"] = ptr_farmLog->environment2.max12v;
+    jref4["current_5_volt_input_in_mv"] = ptr_farmLog->environment2.current5v;
+    jref4["minimum_5_volt_input_in_mv"] = ptr_farmLog->environment2.min5v;
+    jref4["maximum_5_volt_input_in_mv"] = ptr_farmLog->environment2.max5v;
+    jref4["twelve_volt_power_average_in_mw"] = ptr_farmLog->environment.powerAverage12v;
+    // Parameter 5: Reliability Statistics
+    json::ref jref5 = jref["parameter_5_reliability_statistics"];
+    // "By Actuator" Parameters
+    json::ref jrefa = jref["by_actuator_parameters"];
+    json::ref jrefa0 = jrefa["head_load_events"];
+    jrefa0["actuator_0"] = ptr_farmLog->actuator0.headLoadEvents;
+    jrefa0["actuator_1"] = ptr_farmLog->actuator1.headLoadEvents;
+    jrefa0["actuator_2"] = ptr_farmLog->actuator2.headLoadEvents;
+    jrefa0["actuator_3"] = ptr_farmLog->actuator3.headLoadEvents;
+    json::ref jrefa1 = jrefa["lbas_corrected_by_intermediate_super_parity"];
+    jrefa1["actuator_0"] = ptr_farmLog->actuator0.lbasCorrectedISP;
+    jrefa1["actuator_1"] = ptr_farmLog->actuator1.lbasCorrectedISP;
+    jrefa1["actuator_2"] = ptr_farmLog->actuator2.lbasCorrectedISP;
+    jrefa1["actuator_3"] = ptr_farmLog->actuator3.lbasCorrectedISP;
+    json::ref jrefa2 = jrefa["lbas_corrected_by_parity_sector"];
+    jrefa2["actuator_0"] = ptr_farmLog->actuator0.numberLBACorrectedParitySector;
+    jrefa2["actuator_1"] = ptr_farmLog->actuator1.numberLBACorrectedParitySector;
+    jrefa2["actuator_2"] = ptr_farmLog->actuator2.numberLBACorrectedParitySector;
+    jrefa2["actuator_3"] = ptr_farmLog->actuator3.numberLBACorrectedParitySector;
+    // "By Head" Parameters
+    json::ref jrefh = jref["by_head_parameters"];
+    json::ref jrefh0 = jrefh["number_of_reallocated_sectors"];
+    for (unsigned i = 0; i < n; i++) {
+        char h[15];
+        sprintf(h, "head_%i", i);
+        jrefh0[h] = ptr_farmLog->totalReallocations.headValue[i];
+    }
+    json::ref jrefh1 = jrefh["number_of_reallocated_candidate_sectors"];
+    for (unsigned i = 0; i < n; i++) {
+        char h[15];
+        sprintf(h, "head_%i", i);
+        jrefh1[h] = ptr_farmLog->totalReallocationCanidates.headValue[i];
+    }
+    // Private metrics
+    json::ref jrefp = jref["private_metrics"];
+    jrefp["private_metric_5_188"] = ptr_farmLog->reliability.reserved20;
+    jrefp["private_metric_5_196"] = ptr_farmLog->reliability.reserved21;
+    jrefp["private_metric_18_all"] = getMaxValFARM(ptr_farmLog->reserved1.headValue, n);
+    jrefp["private_metric_29_all"] = getMaxValFARM(ptr_farmLog->reserved11.headValue, n);
+    jrefp["private_metric_30_all"] = getMaxValFARM(ptr_farmLog->reserved12.headValue, n);
+    sprintf(str, "%0.01f", (double) getMaxValFARM(ptr_farmLog->reserved19.headValue, n) * 0.1);
+    jrefp["private_metric_48_all"] = str;
+    sprintf(str, "%0.01f", (double) getMaxValFARM(ptr_farmLog->reserved20.headValue, n) * 0.1);
+    jrefp["private_metric_49_all"] = str;
+    sprintf(str, "%0.01f", (double) getMaxValFARM(ptr_farmLog->reserved21.headValue, n) * 0.1);
+    jrefp["private_metric_50_all"] = str;
+    sprintf(str, "%0.01f", (double) getMaxValFARM(ptr_farmLog->reserved22.headValue, n) * 0.1);
+    jrefp["private_metric_51_all"] = str;
+    sprintf(str, "%0.01f", (double) getMaxValFARM(ptr_farmLog->reserved23.headValue, n) * 0.1);
+    jrefp["private_metric_52_all"] = str;
+    sprintf(str, "%0.01f", (double) getMaxValFARM(ptr_farmLog->reserved24.headValue, n) * 0.1);
+    jrefp["private_metric_53_all"] = str;
     return true;
 }
 

--- a/smartmontools/scsiprint.cpp
+++ b/smartmontools/scsiprint.cpp
@@ -849,23 +849,6 @@ scsiPrintSeagateFactoryLPage(scsi_device * device)
 // Seagate Field Access Reliability Metrics (FARM) log (Log page 0x3D, sub-page 0x3)
 
 /*
- *  Simple max element function helper for printing Seagate FARM Logs
- *  
- *  @param  arr:    Array with metric values (uint64_t [])
- *  @param  n:      Size of array (size_t)    
- *  @return Maximum value of given array (uint64_t)
- */
-static uint64_t getMaxValFARM(uint64_t arr[], size_t n) {
-  uint64_t currentMax = 0;
-  for (unsigned i = 0; i < n; i++) {
-    if (arr[i] > currentMax) {
-        currentMax = arr[i];
-    }
-  }
-  return currentMax;
-}
-
-/*
  *  Reads vendor-specific FARM log (SCSI log page 0x3D, sub-page 0x3) data from Seagate
  *  drives and parses data into FARM log structures
  *  Returns parsed structure as defined in scsicmds.h
@@ -1087,19 +1070,6 @@ static bool scsiPrintFarmLog(scsiFarmLog * ptr_farmLog) {
     for (unsigned i = 0; i < n; i++) {
         jout("\t\t\tHead %i: %lu\n", i, ptr_farmLog->totalReallocationCanidates.headValue[i]);
     }
-    // Private metrics
-    jout("\tFARM Log: Private Metrics\n");
-    jout("\t\tPrivate Metric 5-188: %lu\n", ptr_farmLog->reliability.reserved20);
-    jout("\t\tPrivate Metric 5-196: %lu\n", ptr_farmLog->reliability.reserved21);
-    jout("\t\tPrivate Metric 18-All: %lu\n", getMaxValFARM(ptr_farmLog->reserved1.headValue, n));
-    jout("\t\tPrivate Metric 29-All: %lu\n", getMaxValFARM(ptr_farmLog->reserved11.headValue, n));
-    jout("\t\tPrivate Metric 30-All: %lu\n", getMaxValFARM(ptr_farmLog->reserved12.headValue, n));
-    jout("\t\tPrivate Metric 48-All: %0.01f\n", (double) getMaxValFARM(ptr_farmLog->reserved19.headValue, n) * 0.1);
-    jout("\t\tPrivate Metric 49-All: %0.01f\n", (double) getMaxValFARM(ptr_farmLog->reserved20.headValue, n) * 0.1);
-    jout("\t\tPrivate Metric 50-All: %0.01f\n", (double) getMaxValFARM(ptr_farmLog->reserved21.headValue, n) * 0.1);
-    jout("\t\tPrivate Metric 51-All: %0.01f\n", (double) getMaxValFARM(ptr_farmLog->reserved22.headValue, n) * 0.1);
-    jout("\t\tPrivate Metric 52-All: %0.01f\n", (double) getMaxValFARM(ptr_farmLog->reserved23.headValue, n) * 0.1);
-    jout("\t\tPrivate Metric 53-All: %0.01f\n", (double) getMaxValFARM(ptr_farmLog->reserved24.headValue, n) * 0.1);
     // Print JSON if --json or -j is specified
     char str[50];
     json::ref jref = jglb["seagate_farm_log"];
@@ -1158,25 +1128,6 @@ static bool scsiPrintFarmLog(scsiFarmLog * ptr_farmLog) {
         sprintf(h, "head_%i", i);
         jrefh1[h] = ptr_farmLog->totalReallocationCanidates.headValue[i];
     }
-    // Private metrics
-    json::ref jrefp = jref["private_metrics"];
-    jrefp["private_metric_5_188"] = ptr_farmLog->reliability.reserved20;
-    jrefp["private_metric_5_196"] = ptr_farmLog->reliability.reserved21;
-    jrefp["private_metric_18_all"] = getMaxValFARM(ptr_farmLog->reserved1.headValue, n);
-    jrefp["private_metric_29_all"] = getMaxValFARM(ptr_farmLog->reserved11.headValue, n);
-    jrefp["private_metric_30_all"] = getMaxValFARM(ptr_farmLog->reserved12.headValue, n);
-    sprintf(str, "%0.01f", (double) getMaxValFARM(ptr_farmLog->reserved19.headValue, n) * 0.1);
-    jrefp["private_metric_48_all"] = str;
-    sprintf(str, "%0.01f", (double) getMaxValFARM(ptr_farmLog->reserved20.headValue, n) * 0.1);
-    jrefp["private_metric_49_all"] = str;
-    sprintf(str, "%0.01f", (double) getMaxValFARM(ptr_farmLog->reserved21.headValue, n) * 0.1);
-    jrefp["private_metric_50_all"] = str;
-    sprintf(str, "%0.01f", (double) getMaxValFARM(ptr_farmLog->reserved22.headValue, n) * 0.1);
-    jrefp["private_metric_51_all"] = str;
-    sprintf(str, "%0.01f", (double) getMaxValFARM(ptr_farmLog->reserved23.headValue, n) * 0.1);
-    jrefp["private_metric_52_all"] = str;
-    sprintf(str, "%0.01f", (double) getMaxValFARM(ptr_farmLog->reserved24.headValue, n) * 0.1);
-    jrefp["private_metric_53_all"] = str;
     return true;
 }
 

--- a/smartmontools/scsiprint.h
+++ b/smartmontools/scsiprint.h
@@ -29,7 +29,8 @@ struct scsi_print_options
   bool smart_background_log;
   bool smart_ss_media_log;
 
-  bool farm_log; // Seagate Field Access Reliability Metrics log (FARM) for SCSI
+  bool farm_log;    // Seagate Field Access Reliability Metrics log (FARM) for SCSI
+  bool all;         // Helper for FARM debug messages
 
   bool smart_disable, smart_enable;
   bool smart_auto_save_disable, smart_auto_save_enable;
@@ -54,6 +55,7 @@ struct scsi_print_options
       smart_background_log(false),
       smart_ss_media_log(false),
       farm_log(false),
+      all(false),
       smart_disable(false), smart_enable(false),
       smart_auto_save_disable(false), smart_auto_save_enable(false),
       smart_default_selftest(false),

--- a/smartmontools/smartctl.cpp
+++ b/smartmontools/smartctl.cpp
@@ -701,6 +701,8 @@ static int parse_options(int argc, char** argv, const char * & type,
       nvmeopts.error_log_entries   = 16;
       ataopts.smart_selftest_log   = scsiopts.smart_selftest_log  = true;
       ataopts.smart_selective_selftest_log = true;
+      ataopts.farm_log             = scsiopts.farm_log            = true;   // Seagate Field Access Reliability Metrics (FARM) log
+      ataopts.all                  = scsiopts.all                 = true;   // Helper for FARM debug messages
       /* scsiopts.smart_background_log = true; */
       scsiopts.smart_ss_media_log = true;
       break;
@@ -715,6 +717,8 @@ static int parse_options(int argc, char** argv, const char * & type,
       ataopts.smart_ext_selftest_log = 25;
       ataopts.retry_selftest_log   = true;
       scsiopts.smart_error_log     = scsiopts.smart_selftest_log    = true;
+      ataopts.farm_log             = scsiopts.farm_log              = true;   // Seagate Field Access Reliability Metrics (FARM) log
+      ataopts.all                  = scsiopts.all                   = true;   // Helper for FARM debug messages
       ataopts.smart_selective_selftest_log = true;
       ataopts.smart_logdir = ataopts.gp_logdir = true;
       ataopts.sct_temp_sts = ataopts.sct_temp_hist = true;


### PR DESCRIPTION
When run with `-l farm`, smartctl now prints around 20 more informative metrics for Seagate drives supporting FARM logs in both text and JSON formats for both ATA and SCSI.